### PR TITLE
Issue24 test

### DIFF
--- a/hatch/src/assets/builder.rs
+++ b/hatch/src/assets/builder.rs
@@ -6,7 +6,6 @@ use assets::tupfile::Tupfile;
 use assets::platform::{ Linux, MacOS, Windows };
 use assets::tupfile_ini::TupfileIni;
 use project::{ Project, ProjectKind };
-use std::path::PathBuf;
 use task;
 
 pub struct Builder {

--- a/hatch/src/bin/hatch.rs
+++ b/hatch/src/bin/hatch.rs
@@ -7,6 +7,7 @@ use hatch::cli::commands::Command;
 use hatch::cli::commands::new::New;
 use hatch::cli::commands::update::Update;
 use hatch::cli::commands::build::Build;
+use hatch::cli::commands::test::Test;
 
 fn main() {
   // create the subcommand to command map
@@ -20,6 +21,9 @@ fn main() {
 
   let build_command = Box::new(Build::new());
   subcommands.insert(build_command.subcommand_name(), build_command);
+
+  let test_command = Box::new(Test::new());
+  subcommands.insert(test_command.subcommand_name(), test_command);
 
   // initialize cli with the set of subcommand
   let cli = Cli::new(subcommands.values().map(|v| v.cli_subcommand()).collect::<Vec<_>>());

--- a/hatch/src/bin/hatch.rs
+++ b/hatch/src/bin/hatch.rs
@@ -7,6 +7,7 @@ use hatch::cli::commands::Command;
 use hatch::cli::commands::new::New;
 use hatch::cli::commands::update::Update;
 use hatch::cli::commands::build::Build;
+use hatch::cli::commands::test::Test;
 
 use hatch::hatch_error::{ HatchError, NullError };
 
@@ -22,6 +23,9 @@ fn main() {
 
   let build_command = Box::new(Build::new());
   subcommands.insert(build_command.subcommand_name(), build_command);
+
+  let test_command = Box::new(Test::new());
+  subcommands.insert(test_command.subcommand_name(), test_command);
 
   // initialize cli with the set of subcommand
   let cli = Cli::new(subcommands.values().map(|v| v.cli_subcommand()).collect::<Vec<_>>());

--- a/hatch/src/cli/commands/build.rs
+++ b/hatch/src/cli/commands/build.rs
@@ -1,5 +1,5 @@
 use hatch_error::{ HatchResult, ResultExt };
-use clap::{ App, SubCommand, Arg, ArgMatches };
+use clap::{ App, SubCommand, ArgMatches };
 use cli::commands::Command;
 use project::Project;
 use assets::PlatformKind;
@@ -33,7 +33,7 @@ impl<'build> Build {
               .spawn().with_context(|e| {
               format!("failed to build project at `{}` : {}", &path, e)
             })?;
-          child.wait();
+          child.wait()?;
         },
         _ => {
           let mut child =
@@ -43,7 +43,7 @@ impl<'build> Build {
               .spawn().with_context(|e| {
               format!("failed to build project at `{}` : {}", &path, e)
             })?;
-          child.wait();
+          child.wait()?;
         }
       }
     }

--- a/hatch/src/cli/commands/mod.rs
+++ b/hatch/src/cli/commands/mod.rs
@@ -3,6 +3,7 @@ use hatch_error::HatchResult;
 pub mod new;
 pub mod update;
 pub mod build;
+pub mod test;
 
 use project::Project;
 use clap::{ ArgMatches, App };

--- a/hatch/src/cli/commands/mod.rs
+++ b/hatch/src/cli/commands/mod.rs
@@ -1,11 +1,11 @@
-use hatch_error::HatchResult;
-
 pub mod new;
 pub mod update;
 pub mod build;
 pub mod test;
 
+use hatch_error::HatchResult;
 use clap::{ ArgMatches, App };
+use std::path::PathBuf;
 
 static ARGS: &str = "ARGS";
 static INCLUDE: &str = "INCLUDE";

--- a/hatch/src/cli/commands/mod.rs
+++ b/hatch/src/cli/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod new;
 pub mod update;
 pub mod build;
+pub mod test;
 mod ops;
 
 use HatchResult;

--- a/hatch/src/cli/commands/mod.rs
+++ b/hatch/src/cli/commands/mod.rs
@@ -5,7 +5,6 @@ pub mod update;
 pub mod build;
 pub mod test;
 
-use project::Project;
 use clap::{ ArgMatches, App };
 
 static ARGS: &str = "ARGS";

--- a/hatch/src/cli/commands/mod.rs
+++ b/hatch/src/cli/commands/mod.rs
@@ -8,10 +8,12 @@ pub mod test;
 use project::Project;
 use clap::{ ArgMatches, App };
 
+static ARGS: &str = "ARGS";
 static INCLUDE: &str = "INCLUDE";
 static VERSION: &str = "VERSION";
 static BIN: &str = "BIN";
 static STATIC: &str = "STATIC";
+static PROJECT_NAME: &str = "PROJECT_NAME";
 static PROJECT_NAMES: &str = "PROJECT_NAMES";
 static PROJECT_PATH: &str = "PROJECT_PATH";
 
@@ -20,10 +22,10 @@ pub trait Command<'command> {
   
   fn subcommand_name(&self) -> &'static str;
 
-  fn execute(&self, args: &ArgMatches<'command>) -> HatchResult<Project>;
+  fn execute(&self, args: &ArgMatches<'command>) -> HatchResult<()>;
  
   fn project_name(&self, args: &ArgMatches<'command>) -> Option<String> {
-    value_t!(args, PROJECT_NAMES, String).ok()
+    value_t!(args, PROJECT_NAME, String).ok()
   }
   
   fn project_path(&self, args: &ArgMatches<'command>) -> String {

--- a/hatch/src/cli/commands/new.rs
+++ b/hatch/src/cli/commands/new.rs
@@ -1,6 +1,5 @@
 use std::fs;
 use clap::{ App, SubCommand, Arg, ArgMatches };
-<<<<<<< HEAD
 use cli::commands::{ Command, parse_deps_from_cli };
 use repo::{ modules_path, hatchfile_path, clone_project_deps };
 use project::{ Project, ProjectKind, LibraryKind, Dependency };
@@ -12,7 +11,7 @@ use task;
 use std::fmt::Write as FmtWrite;
 use std::io::Write as IoWrite;
 
-use cli::commands::{ INCLUDE, VERSION, STATIC, BIN, PROJECT_NAMES };
+use cli::commands::{ INCLUDE, VERSION, STATIC, BIN, PROJECT_NAME };
 
 pub struct New {
   name: &'static str,
@@ -72,7 +71,7 @@ impl<'command> Command<'command> for New {
     SubCommand::with_name(&self.name)
       .about("Creates a new project. (default = shared library)")
 
-      .arg(Arg::with_name(PROJECT_NAMES)
+      .arg(Arg::with_name(PROJECT_NAME)
            .help("Name of project")
            .takes_value(true)
            .required(true))
@@ -102,7 +101,7 @@ impl<'command> Command<'command> for New {
     self.name
   }
 
-  fn execute(&self, args: &ArgMatches<'command>) -> HatchResult<Project> {
+  fn execute(&self, args: &ArgMatches<'command>) -> HatchResult<()> {
     let name = self.project_name(args).unwrap();
     let version = self.project_version(args);
     let kind = self.project_kind(args);
@@ -112,7 +111,7 @@ impl<'command> Command<'command> for New {
 
     let deps_from_cli = parse_deps_from_cli(args);
     
-    let res = (|| -> HatchResult<_> {
+    let res = (|| -> HatchResult<()> {
       // create directory for new project
       fs::create_dir(&dir_path)?;
       // create the hatch_modules directory inside the project directory
@@ -140,7 +139,7 @@ impl<'command> Command<'command> for New {
       let project = Project::new(name, kind, version, deps, dir_path.to_path_buf());
       task::generate_assets(&project)?;
 
-      Ok(project)
+      Ok(())
     })().with_context(|e| {
       format!("Failed to create project at: `{}` : {}", dir_path.display(), e)
     })?;

--- a/hatch/src/cli/commands/new.rs
+++ b/hatch/src/cli/commands/new.rs
@@ -1,7 +1,7 @@
 use HatchResult;
 use std::fs;
 use clap::{ App, SubCommand, Arg, ArgMatches };
-use cli::commands::{ Command };
+use cli::commands::Command;
 use project::{ Project, ProjectKind, LibraryKind };
 use hatch_error::HatchError;
 

--- a/hatch/src/cli/commands/test.rs
+++ b/hatch/src/cli/commands/test.rs
@@ -1,0 +1,79 @@
+use std::process;
+use cli::commands::Command;
+use cli::commands::ops::ProjectOps;
+use HatchResult;
+use hatch_error::HatchError;
+use project::Project;
+use clap::{ App, SubCommand, Arg, ArgMatches };
+
+struct ImplicitTester;
+struct ExplicitTester;
+
+impl ImplicitTester {
+  fn execute(&self, path: String, _: Vec<String>) {
+
+  }
+}
+
+impl ExplicitTester {
+  fn execute(&self, path: String, project_names: Vec<String>) {
+    for project_name in project_names {
+      let testExecutablePath = path.to_owned() + "test/build/" + project_name.as_str() + ".test";
+
+      let result = process::Command::new(testExecutablePath)
+                                     .arg("--success")
+                                     .output();
+
+      match result {
+        Ok(output) => {
+          println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+        },
+        Err(e) => {
+          println!("{:?}", e);
+        },
+      }
+    }
+  }
+}
+
+pub struct Test {
+  name: &'static str,
+}
+
+impl<'test> Test {
+  pub fn new() -> Test {
+    Test {
+      name: "test",
+    }
+  }
+}
+
+impl<'command> Command<'command> for Test {
+  fn cli_subcommand(&self) -> App<'command, 'command> {
+    SubCommand::with_name(&self.name)
+      .about("Tests a project.")
+      .author("Danny Peck <danieljpeck93@gmail.com>")
+
+      .arg(Arg::with_name("PROJECT_NAMES")
+        .help("The projects to be tested.")
+        .min_values(0)
+        .value_delimiter(" ")
+        .required(false))
+  }
+  
+  fn subcommand_name(&self) -> &'static str {
+    self.name
+  }
+
+  fn execute(&self, args: &ArgMatches<'command>) -> Vec<HatchResult<Project>> {
+    if args.is_present("PROJECT_NAMES") {
+      let tester = Box::new(ExplicitTester);
+      tester.execute(self.project_path(args), self.project_names(args));
+    } else {
+      let tester = Box::new(ImplicitTester);
+      tester.execute(self.project_path(args), self.project_names(args));
+    }
+
+    vec![]
+  }
+}

--- a/hatch/src/cli/commands/test.rs
+++ b/hatch/src/cli/commands/test.rs
@@ -1,0 +1,79 @@
+use std::process;
+use cli::commands::Command;
+use cli::commands::ops::ProjectOps;
+use HatchResult;
+use hatch_error::HatchError;
+use project::Project;
+use clap::{ App, SubCommand, Arg, ArgMatches };
+
+struct ImplicitTester;
+struct ExplicitTester;
+
+impl ImplicitTester {
+  fn execute(&self, path: String, _: Vec<String>) {
+
+  }
+}
+
+impl ExplicitTester {
+  fn execute(&self, path: String, project_names: Vec<String>) {
+    for project_name in project_names {
+      let testExecutablePath = path.to_owned() + "test/build/" + project_name.as_str() + ".test";
+
+      let result = process::Command::new(testExecutablePath)
+                                     .arg("--success")
+                                     .output();
+
+      match result {
+        Ok(output) => {
+          println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+        },
+        Err(e) => {
+          println!("{:?}", e);
+        },
+      }
+    }
+  }
+}
+
+pub struct Test {
+  name: &'static str,
+}
+
+impl<'test> Test {
+  pub fn new() -> Test {
+    Test {
+      name: "test",
+    }
+  }
+}
+
+impl<'command> Command<'command> for Test {
+  fn cli_subcommand(&self) -> App<'command, 'command> {
+    SubCommand::with_name(&self.name)
+      .about("Tests a project.")
+      .author("Danny Peck <danieljpeck93@gmail.com>")
+
+      .arg(Arg::with_name("PROJECT_NAMES")
+        .help("The projects to be tested.")
+        .min_values(0)
+        .value_delimiter(" ")
+        .required(false))
+  }
+
+  fn subcommand_name(&self) -> &'static str {
+    self.name
+  }
+
+  fn execute(&self, args: &ArgMatches<'command>) -> Vec<HatchResult<Project>> {
+    if args.is_present("PROJECT_NAMES") {
+      let tester = Box::new(ExplicitTester);
+      tester.execute(self.project_path(args), self.project_names(args));
+    } else {
+      let tester = Box::new(ImplicitTester);
+      tester.execute(self.project_path(args), self.project_names(args));
+    }
+
+    vec![]
+  }
+}

--- a/hatch/src/cli/commands/test.rs
+++ b/hatch/src/cli/commands/test.rs
@@ -3,7 +3,6 @@ use cli::commands::Command;
 use cli::commands::build::Build;
 use cli::commands::ARGS;
 use hatch_error::{ HatchResult, ResultExt };
-use project::Project;
 use task;
 use clap::{ App, SubCommand, Arg, ArgMatches };
 
@@ -71,7 +70,7 @@ impl<'command> Command<'command> for Test {
         .spawn().with_context(|e| {
           format!("failed to execute test executable `{}` : {}", &test_executable_path, e)
         })?;
-    child.wait();
+    child.wait()?;
 
     Ok(())
   }

--- a/hatch/src/cli/commands/test.rs
+++ b/hatch/src/cli/commands/test.rs
@@ -54,7 +54,9 @@ impl<'command> Command<'command> for Test {
 
       println!("\nBuilding project...\n");
 
-      Build::new().execute(&project)?;
+      Build::new().execute(&project).with_context(|e| {
+        format!("Failed to build project : {}", e)
+      })?;
 
       println!("\nExecuting tests...\n");
 

--- a/hatch/src/cli/commands/test.rs
+++ b/hatch/src/cli/commands/test.rs
@@ -5,6 +5,7 @@ use cli::commands::ARGS;
 use hatch_error::{ HatchResult, ResultExt };
 use task;
 use clap::{ App, SubCommand, Arg, ArgMatches };
+use std::path::PathBuf;
 
 pub struct Test {
   name: &'static str,
@@ -49,7 +50,7 @@ impl<'command> Command<'command> for Test {
     let project_path = self.project_path(args);
 
     let project = task::read_project(&project_path).with_context(|e| {
-      format!("failed to read project at `{}` : {}", project_path, e)
+      format!("failed to read project at `{}` : {}", project_path.display(), e)
     })?;
 
     println!("Building project...\n");
@@ -60,7 +61,7 @@ impl<'command> Command<'command> for Test {
 
     println!("\nExecuting tests...\n");
 
-    let test_executable_path = format!("{}test/target/{}.test", &project_path, project.name());
+    let test_executable_path = format!("{}test/target/{}.test", project_path.display(), project.name());
 
     let test_arguments = parse_test_arguments_from_cli(args);
 

--- a/hatch/src/cli/commands/test.rs
+++ b/hatch/src/cli/commands/test.rs
@@ -6,16 +6,7 @@ use hatch_error::HatchError;
 use project::Project;
 use clap::{ App, SubCommand, Arg, ArgMatches };
 
-struct ImplicitTester;
-struct ExplicitTester;
-
-impl ImplicitTester {
-  fn execute(&self, path: String, _: Vec<String>) {
-
-  }
-}
-
-impl ExplicitTester {
+impl Tester {
   fn execute(&self, path: String, project_names: Vec<String>) {
     for project_name in project_names {
       let testExecutablePath = path.to_owned() + "test/build/" + project_name.as_str() + ".test";
@@ -67,10 +58,7 @@ impl<'command> Command<'command> for Test {
 
   fn execute(&self, args: &ArgMatches<'command>) -> Vec<HatchResult<Project>> {
     if args.is_present("PROJECT_NAMES") {
-      let tester = Box::new(ExplicitTester);
-      tester.execute(self.project_path(args), self.project_names(args));
-    } else {
-      let tester = Box::new(ImplicitTester);
+      let tester = Box::new(Tester);
       tester.execute(self.project_path(args), self.project_names(args));
     }
 

--- a/hatch/src/cli/commands/update.rs
+++ b/hatch/src/cli/commands/update.rs
@@ -35,7 +35,9 @@ impl<'command> Command<'command> for Update {
     self.name
   }
 
-  fn execute(&self, args: &ArgMatches<'command>) -> HatchResult<Project> {
-    task::read_project(&self.project_path(args))
+  fn execute(&self, args: &ArgMatches<'command>) -> HatchResult<()> {
+    task::read_project(&self.project_path(args));
+
+    Ok(())
   }
 }

--- a/hatch/src/cli/commands/update.rs
+++ b/hatch/src/cli/commands/update.rs
@@ -1,7 +1,6 @@
 use hatch_error::HatchResult;
 use clap::{ App, SubCommand, Arg, ArgMatches };
 use cli::commands::Command;
-use project::Project;
 use task;
 
 use cli::commands::PROJECT_NAMES;
@@ -36,7 +35,7 @@ impl<'command> Command<'command> for Update {
   }
 
   fn execute(&self, args: &ArgMatches<'command>) -> HatchResult<()> {
-    task::read_project(&self.project_path(args));
+    task::read_project(&self.project_path(args))?;
 
     Ok(())
   }

--- a/hatch/src/hatch_error/mod.rs
+++ b/hatch/src/hatch_error/mod.rs
@@ -20,5 +20,9 @@ pub struct MissingNameError;
 pub struct MissingVersionError;
 
 #[derive(Fail, Debug)]
+#[fail(display = "Invalid path")]
+pub struct InvalidPathError;
+
+#[derive(Fail, Debug)]
 #[fail(display = "")]
 pub struct NullError;

--- a/hatch/src/task.rs
+++ b/hatch/src/task.rs
@@ -1,7 +1,7 @@
 use project::Project;
 use assets::builder::Builder as AssetBuilder;
 use std::path::Path;
-use hatch_error::HatchResult;
+use hatch_error::{ HatchResult, ResultExt };
 use assets::generator;
 use assets::PlatformKind;
 use repo::hatchfile_path;
@@ -10,11 +10,19 @@ use os_info;
 use os_info::Type::{ Macos, Windows };
 
 pub fn read_project(path: &Path) -> HatchResult<Project> {
-  yaml::parse(hatchfile_path(path).as_path())
+  let project = yaml::parse(hatchfile_path(path).as_path()).with_context(|e| {
+    format!("failed to read project at `{}` : {}", path.display(), e)
+  })?;
+
+  Ok(project)
 }
 
 pub fn generate_assets(project: &Project) -> HatchResult<()> {
-  generator::generate_all(AssetBuilder::from(project).assets())
+  generator::generate_all(AssetBuilder::from(project).assets()).with_context(|e| {
+    format!("asset generation failed : `{}`", e)
+  })?;
+
+  Ok(())
 }
 
 pub fn platform_type() -> PlatformKind {


### PR DESCRIPTION
Added test command that allows the user to execute a project's tests.

The test command supports forwarding arguments to the project's test executable.

The test command will always regenerate the build assets and build the project before executing the tests.

Usage:
```
hatch-test 
Danny Peck <danieljpeck93@gmail.com>
Tests a project.

USAGE:
    hatch test [OPTIONS] [ARGS]...

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -p, --path <PROJECT_PATH>    Path to the project. (default = ./)

ARGS:
    <ARGS>...    The arguments forwarded to the test executable.
```

Example: `hatch test --path ../Project -- --success`