### PR TITLE
Issue65 execute

### DIFF
--- a/hatch/src/bin/hatch.rs
+++ b/hatch/src/bin/hatch.rs
@@ -8,6 +8,7 @@ use hatch::cli::commands::new::New;
 use hatch::cli::commands::update::Update;
 use hatch::cli::commands::build::Build;
 use hatch::cli::commands::test::Test;
+use hatch::cli::commands::run::Run;
 
 fn main() {
   // create the subcommand to command map
@@ -24,6 +25,9 @@ fn main() {
 
   let test_command = Box::new(Test::new());
   subcommands.insert(test_command.subcommand_name(), test_command);
+
+  let run_command = Box::new(Run::new());
+  subcommands.insert(run_command.subcommand_name(), run_command);
 
   // initialize cli with the set of subcommand
   let cli = Cli::new(subcommands.values().map(|v| v.cli_subcommand()).collect::<Vec<_>>());

--- a/hatch/src/cli/commands/mod.rs
+++ b/hatch/src/cli/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod new;
 pub mod update;
 pub mod build;
 pub mod test;
+pub mod run;
 
 use hatch_error::HatchResult;
 use clap::{ ArgMatches, App };

--- a/hatch/src/cli/commands/run.rs
+++ b/hatch/src/cli/commands/run.rs
@@ -1,0 +1,85 @@
+use std::process::Command as ProcessCommand;
+use cli::commands::Command;
+use cli::commands::build::Build;
+use cli::commands::ARGS;
+use hatch_error::{ HatchResult, ResultExt, NullError };
+use task;
+use clap::{ App, SubCommand, Arg, ArgMatches };
+use project::ProjectKind;
+
+pub struct Run {
+  name: &'static str,
+}
+
+impl<'run> Run {
+  pub fn new() -> Run {
+    Run {
+      name: "run",
+    }
+  }
+}
+
+fn parse_run_arguments_from_cli<'command>(cli_args: &ArgMatches<'command>) -> Vec<String> {
+  if let Some(arguments) = cli_args.values_of(ARGS) {
+    arguments.map(String::from).collect()
+  } else {
+    Vec::new()
+  }
+}
+
+impl<'command> Command<'command> for Run {
+  fn cli_subcommand(&self) -> App<'command, 'command> {
+    SubCommand::with_name(&self.name)
+      .about("Executes a project.")
+      .author("Danny Peck <danieljpeck93@gmail.com>")
+
+      .arg(Arg::with_name(ARGS)
+        .help("The arguments forwarded to the executable.")
+        .min_values(0).value_delimiter(" ")
+        .required(false))
+  }
+
+  fn subcommand_name(&self) -> &'static str {
+    self.name
+  }
+
+  fn execute(&self, args: &ArgMatches<'command>) -> HatchResult<()> {
+    let res = (|| -> HatchResult<()> {
+      let project_path = self.project_path(args);
+      let project = task::read_project(&project_path)?;
+
+      match *project.kind() {
+        ProjectKind::Binary => {
+          println!("Generating assets...\n");
+
+          task::generate_assets(&project)?;
+
+          println!("Building project...\n");
+
+          Build::new().execute(&project).with_context(|e| {
+            format!("Failed to build project : {}", e)
+          })?;
+
+          println!("Executing...\n");
+
+          let executable_path = format!("{}target/{}", project_path.display(), project.name());
+          let run_arguments = parse_run_arguments_from_cli(args);
+
+          let mut child = ProcessCommand::new(&executable_path).args(run_arguments).spawn()?;
+          child.wait()?;
+
+          Ok(())
+        },
+        _ => {
+          Err(NullError).with_context(|_e| {
+          format!("Project must be a Binary project.")
+          })?
+        }
+      }
+    })().with_context(|e| {
+      format!("Execution has failed : {}", e)
+    })?;
+
+    Ok(res)
+  }
+}

--- a/hatch/src/cli/commands/run.rs
+++ b/hatch/src/cli/commands/run.rs
@@ -48,7 +48,7 @@ impl<'command> Command<'command> for Run {
       let project_path = self.project_path(args);
       let project = task::read_project(&project_path)?;
 
-      match *project.kind() {
+      match *project.config().kind() {
         ProjectKind::Binary => {
           println!("Generating assets...\n");
 

--- a/hatch/src/cli/commands/run.rs
+++ b/hatch/src/cli/commands/run.rs
@@ -72,7 +72,7 @@ impl<'command> Command<'command> for Run {
         },
         _ => {
           Err(NullError).with_context(|_e| {
-          format!("Project must be a Binary project.")
+            format!("Project must be a Binary project.")
           })?
         }
       }

--- a/hatch/src/cli/commands/run.rs
+++ b/hatch/src/cli/commands/run.rs
@@ -71,9 +71,7 @@ impl<'command> Command<'command> for Run {
           Ok(())
         },
         _ => {
-          Err(NullError).with_context(|_e| {
-            format!("Project must be a Binary project.")
-          })?
+          Err(NullError).context(format!("Project must be a Binary project."))?
         }
       }
     })().with_context(|e| {


### PR DESCRIPTION
Added run command that allows the user to execute a binary project's executable.

The run command supports forwarding arguments to the project's executable.

The run command will always regenerate the build assets and build the project before executing the binary.

Usage:
```
hatch-run 
Danny Peck <danieljpeck93@gmail.com>
Executes a project.

USAGE:
    hatch run [OPTIONS] [ARGS]...

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -p, --path <PROJECT_PATH>    Path to the project. (default = ./)

ARGS:
    <ARGS>...    The arguments forwarded to the executable.
```

Example: `hatch run --path ../Project`.

Note that at the time of this PR we do not have Binary project generation support.