### PR TITLE
issue60-binary-projects

### DIFF
--- a/hatch/src/assets/builder.rs
+++ b/hatch/src/assets/builder.rs
@@ -99,7 +99,7 @@ impl Builder {
 
   pub fn tupfile(&self, project: &Project) -> ProjectAsset {
     let project_path = project.path();
-    let contents = Tupfile::new().to_string();
+    let contents = Tupfile::new(project.config().kind()).to_string();
 
     ProjectAsset::new(project_path.to_path_buf(), Tupfile::name(), contents)
   }

--- a/hatch/src/assets/generator.rs
+++ b/hatch/src/assets/generator.rs
@@ -16,7 +16,7 @@ pub fn generate_one(asset: &ProjectAsset) -> HatchResult<()> {
 
   let contents = asset.contents();
   file.write_all(contents.as_bytes()).with_context(|e| {
-   format!("Failed to write contents to file: `{}` : {}", file_path.display(), e)
+    format!("Failed to write contents to file: `{}` : {}", file_path.display(), e)
   })?;
 
   Ok(())

--- a/hatch/src/assets/tests/builder.rs
+++ b/hatch/src/assets/tests/builder.rs
@@ -2,6 +2,7 @@ use assets::builder::Builder as AssetBuilder;
 use assets::{ Asset, ProjectAsset };
 use std::path::PathBuf;
 use assets::tests::fixtures;
+use project::{ ProjectKind, LibraryKind };
 
 #[test]
 fn add_asset() {
@@ -18,7 +19,7 @@ fn add_asset() {
 
 #[test]
 fn build_config_asset() {
-  let project = fixtures::library_project();
+  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.config(&project);
@@ -31,7 +32,7 @@ fn build_config_asset() {
 
 #[test]
 fn build_test_tupfile_asset() {
-  let project = fixtures::library_project();
+  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.test_tupfile(&project);
@@ -44,7 +45,7 @@ fn build_test_tupfile_asset() {
 
 #[test]
 fn build_tuprules_asset() {
-  let project = fixtures::library_project();
+  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.tuprules(&project);
@@ -93,7 +94,7 @@ PROJECT_LIB = $(PROJECT).$(EXTENSION)");
 
 #[test]
 fn build_tupfile_asset() {
-  let project = fixtures::library_project();
+  let project = fixtures::project(ProjectKind::Library(LibraryKind::Shared));
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.tupfile(&project);
@@ -116,7 +117,7 @@ include_rules
 
 #[test]
 fn build_tupfile_ini_asset() {
-  let project = fixtures::library_project();
+  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.tupfile_ini(&project);
@@ -129,7 +130,7 @@ fn build_tupfile_ini_asset() {
 
 #[test]
 fn build_linux_asset() {
-  let project = fixtures::library_project();
+  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.linux(&project);
@@ -142,7 +143,7 @@ fn build_linux_asset() {
 
 #[test]
 fn build_macos_asset() {
-  let project = fixtures::library_project();
+  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.macos(&project);
@@ -155,7 +156,7 @@ fn build_macos_asset() {
 
 #[test]
 fn build_windows_asset() {
-  let project = fixtures::library_project();
+  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.windows(&project);
@@ -174,7 +175,7 @@ CC = clang++.exe
 
 #[test]
 fn build_catch_definition() {
-  let project = fixtures::library_project();
+  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.catch_definition(&project);

--- a/hatch/src/assets/tests/builder.rs
+++ b/hatch/src/assets/tests/builder.rs
@@ -1,22 +1,24 @@
 use assets::builder::Builder as AssetBuilder;
-use assets::ProjectAsset;
-use project::{ Project, Arch, Target, BuildConfig, ProjectKind, LibraryKind };
+use assets::{ Asset, ProjectAsset };
 use std::path::PathBuf;
+use assets::tests::fixtures;
+
+#[test]
+fn add_asset() {
+  let mut asset_builder = AssetBuilder::new();
+  let asset = ProjectAsset::new(PathBuf::from("./"), String::from("test"), String::from("test"));
+  asset_builder.add_asset(asset);
+
+  let assets = asset_builder.assets();
+
+  assert_eq!(assets.len(), 1);
+
+  assert_eq!(assets[0].name(), "test");
+}
 
 #[test]
 fn build_config_asset() {
-  let config = BuildConfig::new(ProjectKind::Library(LibraryKind::Static),
-                                String::from("g++"),
-                                vec![String::from("-c"), String::from("--std=c++1z")],
-                                vec![String::from("-v")],
-                                Arch::X64,
-                                Target::Release);
-
-  let project = Project::new(String::from("test"),
-                             String::from("0.1.0"),
-                             config,
-                             Vec::new(),
-                             PathBuf::from("./"));
+  let project = fixtures::library_project();
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.config(&project);
@@ -29,18 +31,7 @@ fn build_config_asset() {
 
 #[test]
 fn build_test_tupfile_asset() {
-  let config = BuildConfig::new(ProjectKind::Library(LibraryKind::Static),
-                                String::from("g++"),
-                                vec![String::from("-c"), String::from("--std=c++1z")],
-                                vec![String::from("-v")],
-                                Arch::X64,
-                                Target::Release);
-
-  let project = Project::new(String::from("test"),
-                             String::from("0.1.0"),
-                             config,
-                             Vec::new(),
-                             PathBuf::from("./"));
+  let project = fixtures::library_project();
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.test_tupfile(&project);
@@ -53,18 +44,7 @@ fn build_test_tupfile_asset() {
 
 #[test]
 fn build_tuprules_asset() {
-  let config = BuildConfig::new(ProjectKind::Library(LibraryKind::Shared),
-                                String::from("g++"),
-                                vec![String::from("-c"), String::from("--std=c++1z")],
-                                vec![String::from("-v")],
-                                Arch::X64,
-                                Target::Release);
-
-  let project = Project::new(String::from("test"),
-                             String::from("0.1.0"),
-                             config,
-                             Vec::new(),
-                             PathBuf::from("./"));
+  let project = fixtures::library_project();
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.tuprules(&project);
@@ -78,21 +58,24 @@ CFLAGS += -c --std=c++1z
 LINKFLAGS += $(ARCH)
 LINKFLAGS += -v
 ifneq (@(TUP_PLATFORM),macosx)
-  LINKFLAGS += -dynamic
+  LINKFLAGS += -static
 endif
 SOURCE = src
 TARGET = target
 SOURCE_TARGET = $(TARGET)
 SOURCE_FILES = $(SOURCE)/*.cpp
 SOURCE_OBJ_FILES = $(SOURCE_TARGET)/*.o
+
 TEST = test
 TEST_TARGET = $(TEST)/$(TARGET)
 TEST_FILES = $(TEST)/$(SOURCE)/*.cpp
 TEST_OBJ_FILES = $(TEST_TARGET)/*.o
+
 # macros
 !compile = |> $(CC) $(CFLAGS) %f -o %o |>
 !archive = |> ar crs %o %f |>
 !link = |> $(CC) $(LINKFLAGS) %f -o %o |>
+
 # includes the STATIC and SHARED variables for the target platform
 include @(TUP_PLATFORM).tup
 ifeq ($(LIB_TYPE),static)
@@ -100,10 +83,6 @@ ifeq ($(LIB_TYPE),static)
 else
   ifeq ($(LIB_TYPE),shared)
     EXTENSION = $(SHARED)
-  else
-    ifeq ($(LIB_TYPE),both)
-      EXTENSION = both
-    endif
   endif
 endif
 PROJECT_LIB = $(PROJECT).$(EXTENSION)");
@@ -114,18 +93,7 @@ PROJECT_LIB = $(PROJECT).$(EXTENSION)");
 
 #[test]
 fn build_tupfile_asset() {
-  let config = BuildConfig::new(ProjectKind::Library(LibraryKind::Static),
-                                String::from("g++"),
-                                vec![String::from("-c"), String::from("--std=c++1z")],
-                                vec![String::from("-v")],
-                                Arch::X64,
-                                Target::Release);
-
-  let project = Project::new(String::from("test"),
-                             String::from("0.1.0"),
-                             config,
-                             Vec::new(),
-                             PathBuf::from("./"));
+  let project = fixtures::library_project();
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.tupfile(&project);
@@ -134,21 +102,12 @@ fn build_tupfile_asset() {
 "include config.tup
 include_rules
 
-# override build variables
-# VARIABLE = new_value
-
-# define custom build variables
-
-# Compile Source
 : foreach $(SOURCE_FILES) |> !compile |> $(SOURCE_TARGET)/%B.o
 
-# Archive Source
 : $(SOURCE_OBJ_FILES) |> !archive |> $(SOURCE_TARGET)/$(PROJECT_LIB) <$(PROJECT)>
 
-# Compile Tests
 : foreach $(TEST_FILES) |> !compile |> $(TEST_TARGET)/%B.o
 
-# Create Link Executable
 : $(TEST_OBJ_FILES) $(SOURCE_TARGET)/$(PROJECT_LIB) |> !link |> $(TEST_TARGET)/$(PROJECT).test");
   let expected_asset = ProjectAsset::new(PathBuf::from("./"), String::from("Tupfile"), expected_contents);
 
@@ -157,18 +116,7 @@ include_rules
 
 #[test]
 fn build_tupfile_ini_asset() {
-  let config = BuildConfig::new(ProjectKind::Library(LibraryKind::Static),
-                                String::from("g++"),
-                                vec![String::from("-c"), String::from("--std=c++1z")],
-                                vec![String::from("-v")],
-                                Arch::X64,
-                                Target::Release);
-
-  let project = Project::new(String::from("test"),
-                             String::from("0.1.0"),
-                             config,
-                             Vec::new(),
-                             PathBuf::from("./"));
+  let project = fixtures::library_project();
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.tupfile_ini(&project);
@@ -181,18 +129,7 @@ fn build_tupfile_ini_asset() {
 
 #[test]
 fn build_linux_asset() {
-  let config = BuildConfig::new(ProjectKind::Library(LibraryKind::Shared),
-                                String::from("g++"),
-                                vec![String::from("-c"), String::from("--std=c++1z")],
-                                vec![String::from("-v")],
-                                Arch::X64,
-                                Target::Release);
-
-  let project = Project::new(String::from("test"),
-                             String::from("0.1.0"),
-                             config,
-                             Vec::new(),
-                             PathBuf::from("./"));
+  let project = fixtures::library_project();
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.linux(&project);
@@ -205,18 +142,7 @@ fn build_linux_asset() {
 
 #[test]
 fn build_macos_asset() {
-  let config = BuildConfig::new(ProjectKind::Library(LibraryKind::Shared),
-                                String::from("g++"),
-                                vec![String::from("-c"), String::from("--std=c++1z")],
-                                vec![String::from("-v")],
-                                Arch::X64,
-                                Target::Release);
-
-  let project = Project::new(String::from("test"),
-                             String::from("0.1.0"),
-                             config,
-                             Vec::new(),
-                             PathBuf::from("./"));
+  let project = fixtures::library_project();
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.macos(&project);
@@ -229,18 +155,7 @@ fn build_macos_asset() {
 
 #[test]
 fn build_windows_asset() {
-  let config = BuildConfig::new(ProjectKind::Library(LibraryKind::Shared),
-                                String::from("g++"),
-                                vec![String::from("-c"), String::from("--std=c++1z")],
-                                vec![String::from("-v")],
-                                Arch::X64,
-                                Target::Release);
-
-  let project = Project::new(String::from("test"),
-                             String::from("0.1.0"),
-                             config,
-                             Vec::new(),
-                             PathBuf::from("./"));
+  let project = fixtures::library_project();
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.windows(&project);
@@ -253,6 +168,19 @@ CC = clang++.exe
 # Use llvm-lib for static libraries
 !archive = |> llvm-lib /MACHINE:X64 /OUT:%o %f |>");
   let expected_asset = ProjectAsset::new(PathBuf::from("./"), String::from("win32.tup"), expected_contents);
+
+  assert_eq!(actual_asset, expected_asset);
+}
+
+#[test]
+fn build_catch_definition() {
+  let project = fixtures::library_project();
+
+  let asset_builder = AssetBuilder::new();
+  let actual_asset = asset_builder.catch_definition(&project);
+
+  let expected_contents = String::from("#define CATCH_CONFIG_MAIN\n#include \"catch.hpp\"");
+  let expected_asset = ProjectAsset::new(PathBuf::from("./"), String::from("catch.cpp"), expected_contents);
 
   assert_eq!(actual_asset, expected_asset);
 }

--- a/hatch/src/assets/tests/catch_definition.rs
+++ b/hatch/src/assets/tests/catch_definition.rs
@@ -1,0 +1,6 @@
+use assets::catch_definition::CatchDefinition;
+
+#[test]
+fn build_catch_definition() {
+  assert_eq!("#define CATCH_CONFIG_MAIN\n#include \"catch.hpp\"", CatchDefinition::new().to_string());
+}

--- a/hatch/src/assets/tests/catch_header.rs
+++ b/hatch/src/assets/tests/catch_header.rs
@@ -1,0 +1,6 @@
+use assets::catch_header::CatchHeader;
+
+#[test]
+fn build_catch_header() {
+  assert_eq!("catch.hpp", CatchHeader::name());
+}

--- a/hatch/src/assets/tests/fixtures.rs
+++ b/hatch/src/assets/tests/fixtures.rs
@@ -1,0 +1,36 @@
+use project::{ Project, Arch, Target, BuildConfig, ProjectKind, LibraryKind };
+use std::path::PathBuf;
+
+pub fn library_project() -> Project {
+  let config = BuildConfig::new(ProjectKind::Library(LibraryKind::Static),
+                                String::from("g++"),
+                                vec![String::from("-c"), String::from("--std=c++1z")],
+                                vec![String::from("-v")],
+                                Arch::X64,
+                                Target::Release);
+
+  let project = Project::new(String::from("test"),
+                             String::from("0.1.0"),
+                             config,
+                             Vec::new(),
+                             PathBuf::from("./"));
+
+  project
+}
+
+pub fn binary_project() -> Project {
+  let config = BuildConfig::new(ProjectKind::Binary,
+                                String::from("g++"),
+                                vec![String::from("-c"), String::from("--std=c++1z")],
+                                vec![String::from("-v")],
+                                Arch::X64,
+                                Target::Release);
+
+  let project = Project::new(String::from("test"),
+                             String::from("0.1.0"),
+                             config,
+                             Vec::new(),
+                             PathBuf::from("./"));
+
+  project
+}

--- a/hatch/src/assets/tests/fixtures.rs
+++ b/hatch/src/assets/tests/fixtures.rs
@@ -1,25 +1,8 @@
-use project::{ Project, Arch, Target, BuildConfig, ProjectKind, LibraryKind };
+use project::{ Project, Arch, Target, BuildConfig, ProjectKind };
 use std::path::PathBuf;
 
-pub fn library_project() -> Project {
-  let config = BuildConfig::new(ProjectKind::Library(LibraryKind::Static),
-                                String::from("g++"),
-                                vec![String::from("-c"), String::from("--std=c++1z")],
-                                vec![String::from("-v")],
-                                Arch::X64,
-                                Target::Release);
-
-  let project = Project::new(String::from("test"),
-                             String::from("0.1.0"),
-                             config,
-                             Vec::new(),
-                             PathBuf::from("./"));
-
-  project
-}
-
-pub fn binary_project() -> Project {
-  let config = BuildConfig::new(ProjectKind::Binary,
+pub fn project(kind: ProjectKind) -> Project {
+  let config = BuildConfig::new(kind,
                                 String::from("g++"),
                                 vec![String::from("-c"), String::from("--std=c++1z")],
                                 vec![String::from("-v")],

--- a/hatch/src/assets/tests/generator.rs
+++ b/hatch/src/assets/tests/generator.rs
@@ -50,9 +50,7 @@ fn generate_one_with_directories() {
         panic!(e);
       }
 
-      if let Err(e) = fs::remove_dir("./foo/") {
-        panic!(e);
-      }
+      fs::remove_dir("./foo/");
     },
     Err(e) => panic!(e)
   }

--- a/hatch/src/assets/tests/generator.rs
+++ b/hatch/src/assets/tests/generator.rs
@@ -15,17 +15,19 @@ fn generate_one_without_directories() {
   match fs::File::open("./test.test") {
     Ok(mut file) => {
       let mut contents = String::new();
-      if let Err(e) = file.read_to_string(&mut contents) {
-        panic!(e);
+      let result = file.read_to_string(&mut contents);
+      fs::remove_file("./test.test");
+
+      if let Err(e) = result {
+        panic!(e)
       }
     
       assert_eq!(contents, "test");
-      
-      if let Err(e) = fs::remove_file("./test.test") {
-        panic!(e);
-      }
     },
-    Err(e) => panic!(e)
+    Err(e) => {
+      fs::remove_file("./test.test");
+      panic!(e)
+    }
   }
 }
 
@@ -40,19 +42,19 @@ fn generate_one_with_directories() {
   match fs::File::open("./foo/test.test") {
     Ok(mut file) => {
       let mut contents = String::new();
-      if let Err(e) = file.read_to_string(&mut contents) {
-        panic!(e);
-      }
-    
-      assert_eq!(contents, "test");
-
-      if let Err(e) = fs::remove_file("./foo/test.test") {
-        panic!(e);
-      }
-
+      let result = file.read_to_string(&mut contents);
+      fs::remove_file("./foo/test.test");
       fs::remove_dir("./foo/");
+
+      if let Err(e) = result {
+        panic!(e)
+      }
     },
-    Err(e) => panic!(e)
+    Err(e) => {
+      fs::remove_file("./foo/test.test");
+      fs::remove_dir("./foo/");
+      panic!(e)
+    }
   }
 }
 
@@ -68,18 +70,25 @@ fn generate_one_overwrites_file() {
   match fs::File::open("./test2.test") {
     Ok(mut file) => {
       let mut contents = String::new();
-      if let Err(e) = file.read_to_string(&mut contents) {
-        panic!(e);
+      let result = file.read_to_string(&mut contents);
+      fs::remove_file("./test2.test");
+
+      if let Err(e) = result {
+        panic!(e)
       }
-    
+
       assert_eq!(contents, "old");
     },
-    Err(e) => panic!(e)
+    Err(e) => {
+      fs::remove_file("./test2.test");
+      panic!(e)
+    }
   }
 
   let test_asset = ProjectAsset::new(PathBuf::from("./"), String::from("test2.test"), String::from("new"));
 
   if let Err(e) = generate_one(&test_asset) {
+    fs::remove_file("./test2.test");
     panic!(e);
   }
 
@@ -87,17 +96,19 @@ fn generate_one_overwrites_file() {
   match fs::File::open("./test2.test") {
     Ok(mut file) => {
       let mut contents = String::new();
-      if let Err(e) = file.read_to_string(&mut contents) {
-        panic!(e);
+      let result = file.read_to_string(&mut contents);
+      fs::remove_file("./test2.test");
+
+      if let Err(e) = result {
+        panic!(e)
       }
     
       assert_eq!(contents, "new");
-      
-      if let Err(e) = fs::remove_file("./test2.test") {
-        panic!(e);
-      }
     },
-    Err(e) => panic!(e)
+    Err(e) => {
+      fs::remove_file("./test2.test");
+      panic!(e)
+    }
   }
 }
 
@@ -109,38 +120,46 @@ fn generate_all_assets() {
   let test_assets = vec![test_asset_one, test_asset_two];
 
   if let Err(e) = generate_all(&test_assets) {
+    fs::remove_file("./one.test");
+    fs::remove_file("./two.test");
     panic!(e);
   }
 
   match fs::File::open("./one.test") {
     Ok(mut file) => {
       let mut contents = String::new();
-      if let Err(e) = file.read_to_string(&mut contents) {
-        panic!(e);
+      let result = file.read_to_string(&mut contents);
+      fs::remove_file("./one.test");
+
+      if let Err(e) = result {
+        fs::remove_file("./two.test");
+        panic!(e)
       }
     
       assert_eq!(contents, "one");
-      
-      if let Err(e) = fs::remove_file("./one.test") {
-        panic!(e);
-      }
     },
-    Err(e) => panic!(e)
+    Err(e) => {
+      fs::remove_file("./one.test");
+      fs::remove_file("./two.test");
+      panic!(e)
+    }
   }
 
     match fs::File::open("./two.test") {
     Ok(mut file) => {
       let mut contents = String::new();
-      if let Err(e) = file.read_to_string(&mut contents) {
-        panic!(e);
+      let result = file.read_to_string(&mut contents);
+      fs::remove_file("./two.test");
+
+      if let Err(e) = result {
+        panic!(e)
       }
     
       assert_eq!(contents, "two");
-      
-      if let Err(e) = fs::remove_file("./two.test") {
-        panic!(e);
-      }
     },
-    Err(e) => panic!(e)
+    Err(e) => {
+      fs::remove_file("./two.test");
+      panic!(e)
+    }
   }
 }

--- a/hatch/src/assets/tests/generator.rs
+++ b/hatch/src/assets/tests/generator.rs
@@ -8,16 +8,22 @@ use std::path::PathBuf;
 fn generate_one_without_directories() {
   let test_asset = ProjectAsset::new(PathBuf::from("./"), String::from("test.test"), String::from("test"));
 
-  generate_one(&test_asset);
+  if let Err(e) = generate_one(&test_asset) {
+    panic!(e);
+  }
 
   match fs::File::open("./test.test") {
     Ok(mut file) => {
       let mut contents = String::new();
-      file.read_to_string(&mut contents);
+      if let Err(e) = file.read_to_string(&mut contents) {
+        panic!(e);
+      }
     
       assert_eq!(contents, "test");
       
-      fs::remove_file("./test.test");
+      if let Err(e) = fs::remove_file("./test.test") {
+        panic!(e);
+      }
     },
     Err(e) => panic!(e)
   }
@@ -27,17 +33,26 @@ fn generate_one_without_directories() {
 fn generate_one_with_directories() {
   let test_asset = ProjectAsset::new(PathBuf::from("./test/"), String::from("test.test"), String::from("test"));
 
-  generate_one(&test_asset);
+  if let Err(e) = generate_one(&test_asset) {
+    panic!(e);
+  }
 
   match fs::File::open("./test/test.test") {
     Ok(mut file) => {
       let mut contents = String::new();
-      file.read_to_string(&mut contents);
+      if let Err(e) = file.read_to_string(&mut contents) {
+        panic!(e);
+      }
     
       assert_eq!(contents, "test");
       
-      fs::remove_file("./test/test.test");
-      fs::remove_dir("./test/");
+      if let Err(e) = fs::remove_file("./test/test.test") {
+        panic!(e);
+      }
+
+      if let Err(e) = fs::remove_dir("./test/") {
+        panic!(e);
+      }
     },
     Err(e) => panic!(e)
   }
@@ -47,13 +62,17 @@ fn generate_one_with_directories() {
 fn generate_one_overwrites_file() {
   let test_asset = ProjectAsset::new(PathBuf::from("./"), String::from("test2.test"), String::from("old"));
 
-  generate_one(&test_asset);
+  if let Err(e) = generate_one(&test_asset) {
+    panic!(e);
+  }
 
   // verify that the old content is there
   match fs::File::open("./test2.test") {
     Ok(mut file) => {
       let mut contents = String::new();
-      file.read_to_string(&mut contents);
+      if let Err(e) = file.read_to_string(&mut contents) {
+        panic!(e);
+      }
     
       assert_eq!(contents, "old");
     },
@@ -62,17 +81,23 @@ fn generate_one_overwrites_file() {
 
   let test_asset = ProjectAsset::new(PathBuf::from("./"), String::from("test2.test"), String::from("new"));
 
-  generate_one(&test_asset);
+  if let Err(e) = generate_one(&test_asset) {
+    panic!(e);
+  }
 
   // verify that the new content overwrites the old content
   match fs::File::open("./test2.test") {
     Ok(mut file) => {
       let mut contents = String::new();
-      file.read_to_string(&mut contents);
+      if let Err(e) = file.read_to_string(&mut contents) {
+        panic!(e);
+      }
     
       assert_eq!(contents, "new");
       
-      fs::remove_file("./test2.test");
+      if let Err(e) = fs::remove_file("./test2.test") {
+        panic!(e);
+      }
     },
     Err(e) => panic!(e)
   }
@@ -85,16 +110,22 @@ fn generate_all_assets() {
 
   let test_assets = vec![test_asset_one, test_asset_two];
 
-  generate_all(&test_assets);
+  if let Err(e) = generate_all(&test_assets) {
+    panic!(e);
+  }
 
   match fs::File::open("./one.test") {
     Ok(mut file) => {
       let mut contents = String::new();
-      file.read_to_string(&mut contents);
+      if let Err(e) = file.read_to_string(&mut contents) {
+        panic!(e);
+      }
     
       assert_eq!(contents, "one");
       
-      fs::remove_file("./one.test");
+      if let Err(e) = fs::remove_file("./one.test") {
+        panic!(e);
+      }
     },
     Err(e) => panic!(e)
   }
@@ -102,11 +133,15 @@ fn generate_all_assets() {
     match fs::File::open("./two.test") {
     Ok(mut file) => {
       let mut contents = String::new();
-      file.read_to_string(&mut contents);
+      if let Err(e) = file.read_to_string(&mut contents) {
+        panic!(e);
+      }
     
       assert_eq!(contents, "two");
       
-      fs::remove_file("./two.test");
+      if let Err(e) = fs::remove_file("./two.test") {
+        panic!(e);
+      }
     },
     Err(e) => panic!(e)
   }

--- a/hatch/src/assets/tests/generator.rs
+++ b/hatch/src/assets/tests/generator.rs
@@ -31,13 +31,13 @@ fn generate_one_without_directories() {
 
 #[test]
 fn generate_one_with_directories() {
-  let test_asset = ProjectAsset::new(PathBuf::from("./test/"), String::from("test.test"), String::from("test"));
+  let test_asset = ProjectAsset::new(PathBuf::from("./foo/"), String::from("test.test"), String::from("test"));
 
   if let Err(e) = generate_one(&test_asset) {
     panic!(e);
   }
 
-  match fs::File::open("./test/test.test") {
+  match fs::File::open("./foo/test.test") {
     Ok(mut file) => {
       let mut contents = String::new();
       if let Err(e) = file.read_to_string(&mut contents) {
@@ -45,12 +45,12 @@ fn generate_one_with_directories() {
       }
     
       assert_eq!(contents, "test");
-      
-      if let Err(e) = fs::remove_file("./test/test.test") {
+
+      if let Err(e) = fs::remove_file("./foo/test.test") {
         panic!(e);
       }
 
-      if let Err(e) = fs::remove_dir("./test/") {
+      if let Err(e) = fs::remove_dir("./foo/") {
         panic!(e);
       }
     },

--- a/hatch/src/assets/tests/mod.rs
+++ b/hatch/src/assets/tests/mod.rs
@@ -5,3 +5,6 @@ mod platform;
 mod test_tupfile;
 mod tupfile;
 mod tuprules;
+mod catch_header;
+mod catch_definition;
+mod fixtures;

--- a/hatch/src/assets/tests/mod.rs
+++ b/hatch/src/assets/tests/mod.rs
@@ -8,3 +8,14 @@ mod tuprules;
 mod catch_header;
 mod catch_definition;
 mod fixtures;
+
+use assets::ProjectAsset;
+use std::path::PathBuf;
+
+#[test]
+fn fmt_project_asset() {
+  let asset = ProjectAsset::new(PathBuf::from("./"), String::from("test"), String::from("test"));
+
+  let result = format!("{:?}", asset);
+  assert_eq!(result, "path: ./, name: test, contents: test");
+}

--- a/hatch/src/assets/tests/tupfile.rs
+++ b/hatch/src/assets/tests/tupfile.rs
@@ -1,27 +1,40 @@
 use assets::tupfile::Tupfile;
+use assets::tests::fixtures;
 
 #[test]
-fn build_tupfile() {
+fn build_library_tupfile() {
+  let project = fixtures::library_project();
+
   let contents = String::from(
 "include config.tup
 include_rules
 
-# override build variables
-# VARIABLE = new_value
-
-# define custom build variables
-
-# Compile Source
 : foreach $(SOURCE_FILES) |> !compile |> $(SOURCE_TARGET)/%B.o
 
-# Archive Source
 : $(SOURCE_OBJ_FILES) |> !archive |> $(SOURCE_TARGET)/$(PROJECT_LIB) <$(PROJECT)>
 
-# Compile Tests
 : foreach $(TEST_FILES) |> !compile |> $(TEST_TARGET)/%B.o
 
-# Create Link Executable
 : $(TEST_OBJ_FILES) $(SOURCE_TARGET)/$(PROJECT_LIB) |> !link |> $(TEST_TARGET)/$(PROJECT).test");
 
-  assert_eq!(contents, Tupfile::new().to_string());
+  assert_eq!(contents, Tupfile::new(project.config().kind()).to_string());
+}
+
+#[test]
+fn build_binary_tupfile() {
+  let project = fixtures::binary_project();
+
+  let contents = String::from(
+"include config.tup
+include_rules
+
+: foreach $(SOURCE_FILES) |> !compile |> $(SOURCE_TARGET)/%B.o
+
+: $(SOURCE_OBJ_FILES) |> !link |> $(SOURCE_TARGET)/$(PROJECT)
+
+: foreach $(TEST_FILES) |> !compile |> $(TEST_TARGET)/%B.o
+
+: $(TEST_OBJ_FILES) |> !link |> $(TEST_TARGET)/$(PROJECT).test");
+
+  assert_eq!(contents, Tupfile::new(project.config().kind()).to_string());
 }

--- a/hatch/src/assets/tests/tupfile.rs
+++ b/hatch/src/assets/tests/tupfile.rs
@@ -1,9 +1,10 @@
 use assets::tupfile::Tupfile;
 use assets::tests::fixtures;
+use project::{ ProjectKind, LibraryKind };
 
 #[test]
 fn build_library_tupfile() {
-  let project = fixtures::library_project();
+  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
 
   let contents = String::from(
 "include config.tup
@@ -22,7 +23,7 @@ include_rules
 
 #[test]
 fn build_binary_tupfile() {
-  let project = fixtures::binary_project();
+  let project = fixtures::project(ProjectKind::Binary);
 
   let contents = String::from(
 "include config.tup

--- a/hatch/src/assets/tests/tuprules.rs
+++ b/hatch/src/assets/tests/tuprules.rs
@@ -1,12 +1,182 @@
 use assets::tuprules::Tuprules;
 use project::{ ProjectKind, Arch, BuildConfig, Target, LibraryKind };
 
+/**
+ * These tests were created using All-Pairs testing.
+ *
+ * Note that I am not including the Compiler field as it is required and we are simply doing a
+ * string replace as opposed to an enumeration.
+ *
+ * the tests are following this table:
+ * (Kind,   Arch,  Target, Compiler Flags, Linker Flags)
+ * (Static,  X64, Release,        Present,      Present)
+ * (Static,  X86,   Debug,           None,         None)
+ * (Shared,  X64,   Debug,           None,         None)
+ * (Shared,  X86, Release,        Present,      Present)
+ * (Binary,  X64, Release,           None,         None)
+ * (Binary,  X86,   Debug,        Present,      Present)
+ */
+
 #[test]
-fn build_tuprules() {
+fn build_static_x64_release_with_flags_tuprules() {
   let contents = String::from(
 ".gitignore
 CC = g++
 ARCH = -m64
+CFLAGS += $(ARCH)
+CFLAGS += -c --std=c++1z
+LINKFLAGS += $(ARCH)
+LINKFLAGS += -v
+ifneq (@(TUP_PLATFORM),macosx)
+  LINKFLAGS += -static
+endif
+SOURCE = src
+TARGET = target
+SOURCE_TARGET = $(TARGET)
+SOURCE_FILES = $(SOURCE)/*.cpp
+SOURCE_OBJ_FILES = $(SOURCE_TARGET)/*.o
+
+TEST = test
+TEST_TARGET = $(TEST)/$(TARGET)
+TEST_FILES = $(TEST)/$(SOURCE)/*.cpp
+TEST_OBJ_FILES = $(TEST_TARGET)/*.o
+
+# macros
+!compile = |> $(CC) $(CFLAGS) %f -o %o |>
+!archive = |> ar crs %o %f |>
+!link = |> $(CC) $(LINKFLAGS) %f -o %o |>
+
+# includes the STATIC and SHARED variables for the target platform
+include @(TUP_PLATFORM).tup
+ifeq ($(LIB_TYPE),static)
+  EXTENSION = $(STATIC)
+else
+  ifeq ($(LIB_TYPE),shared)
+    EXTENSION = $(SHARED)
+  endif
+endif
+PROJECT_LIB = $(PROJECT).$(EXTENSION)");
+
+  let config = BuildConfig::new(ProjectKind::Library(LibraryKind::Static),
+                                String::from("g++"),
+                                vec![String::from("-c"), String::from("--std=c++1z")],
+                                vec![String::from("-v")],
+                                Arch::X64,
+                                Target::Release);
+
+  let tuprules = Tuprules::new(&config);
+
+  assert_eq!(contents, tuprules.to_string());
+}
+
+#[test]
+fn build_static_x86_debug_without_flags_tuprules() {
+  let contents = String::from(
+".gitignore
+CC = g++
+CFLAGS += -g
+ARCH = -m32
+CFLAGS += $(ARCH)
+LINKFLAGS += $(ARCH)
+ifneq (@(TUP_PLATFORM),macosx)
+  LINKFLAGS += -static
+endif
+SOURCE = src
+TARGET = target
+SOURCE_TARGET = $(TARGET)
+SOURCE_FILES = $(SOURCE)/*.cpp
+SOURCE_OBJ_FILES = $(SOURCE_TARGET)/*.o
+
+TEST = test
+TEST_TARGET = $(TEST)/$(TARGET)
+TEST_FILES = $(TEST)/$(SOURCE)/*.cpp
+TEST_OBJ_FILES = $(TEST_TARGET)/*.o
+
+# macros
+!compile = |> $(CC) $(CFLAGS) %f -o %o |>
+!archive = |> ar crs %o %f |>
+!link = |> $(CC) $(LINKFLAGS) %f -o %o |>
+
+# includes the STATIC and SHARED variables for the target platform
+include @(TUP_PLATFORM).tup
+ifeq ($(LIB_TYPE),static)
+  EXTENSION = $(STATIC)
+else
+  ifeq ($(LIB_TYPE),shared)
+    EXTENSION = $(SHARED)
+  endif
+endif
+PROJECT_LIB = $(PROJECT).$(EXTENSION)");
+
+  let config = BuildConfig::new(ProjectKind::Library(LibraryKind::Static),
+                                String::from("g++"),
+                                Vec::new(),
+                                Vec::new(),
+                                Arch::X86,
+                                Target::Debug);
+
+  let tuprules = Tuprules::new(&config);
+
+  assert_eq!(contents, tuprules.to_string());
+}
+
+#[test]
+fn build_shared_x64_debug_without_flags_tuprules() {
+  let contents = String::from(
+".gitignore
+CC = g++
+CFLAGS += -g
+ARCH = -m64
+CFLAGS += $(ARCH)
+LINKFLAGS += $(ARCH)
+ifneq (@(TUP_PLATFORM),macosx)
+  LINKFLAGS += -dynamic
+endif
+SOURCE = src
+TARGET = target
+SOURCE_TARGET = $(TARGET)
+SOURCE_FILES = $(SOURCE)/*.cpp
+SOURCE_OBJ_FILES = $(SOURCE_TARGET)/*.o
+
+TEST = test
+TEST_TARGET = $(TEST)/$(TARGET)
+TEST_FILES = $(TEST)/$(SOURCE)/*.cpp
+TEST_OBJ_FILES = $(TEST_TARGET)/*.o
+
+# macros
+!compile = |> $(CC) $(CFLAGS) %f -o %o |>
+!archive = |> ar crs %o %f |>
+!link = |> $(CC) $(LINKFLAGS) %f -o %o |>
+
+# includes the STATIC and SHARED variables for the target platform
+include @(TUP_PLATFORM).tup
+ifeq ($(LIB_TYPE),static)
+  EXTENSION = $(STATIC)
+else
+  ifeq ($(LIB_TYPE),shared)
+    EXTENSION = $(SHARED)
+  endif
+endif
+PROJECT_LIB = $(PROJECT).$(EXTENSION)");
+
+  let config = BuildConfig::new(ProjectKind::Library(LibraryKind::Shared),
+                                String::from("g++"),
+                                Vec::new(),
+                                Vec::new(),
+                                Arch::X64,
+                                Target::Debug);
+
+  let tuprules = Tuprules::new(&config);
+
+  assert_eq!(contents, tuprules.to_string());
+}
+
+#[test]
+fn build_shared_x86_release_with_flags_tuprules() {
+  let contents = String::from(
+".gitignore
+CC = g++
+ARCH = -m32
 CFLAGS += $(ARCH)
 CFLAGS += -c --std=c++1z
 LINKFLAGS += $(ARCH)
@@ -19,14 +189,17 @@ TARGET = target
 SOURCE_TARGET = $(TARGET)
 SOURCE_FILES = $(SOURCE)/*.cpp
 SOURCE_OBJ_FILES = $(SOURCE_TARGET)/*.o
+
 TEST = test
 TEST_TARGET = $(TEST)/$(TARGET)
 TEST_FILES = $(TEST)/$(SOURCE)/*.cpp
 TEST_OBJ_FILES = $(TEST_TARGET)/*.o
+
 # macros
 !compile = |> $(CC) $(CFLAGS) %f -o %o |>
 !archive = |> ar crs %o %f |>
 !link = |> $(CC) $(LINKFLAGS) %f -o %o |>
+
 # includes the STATIC and SHARED variables for the target platform
 include @(TUP_PLATFORM).tup
 ifeq ($(LIB_TYPE),static)
@@ -34,10 +207,6 @@ ifeq ($(LIB_TYPE),static)
 else
   ifeq ($(LIB_TYPE),shared)
     EXTENSION = $(SHARED)
-  else
-    ifeq ($(LIB_TYPE),both)
-      EXTENSION = both
-    endif
   endif
 endif
 PROJECT_LIB = $(PROJECT).$(EXTENSION)");
@@ -46,8 +215,89 @@ PROJECT_LIB = $(PROJECT).$(EXTENSION)");
                                 String::from("g++"),
                                 vec![String::from("-c"), String::from("--std=c++1z")],
                                 vec![String::from("-v")],
+                                Arch::X86,
+                                Target::Release);
+
+  let tuprules = Tuprules::new(&config);
+
+  assert_eq!(contents, tuprules.to_string());
+}
+
+#[test]
+fn build_binary_x64_release_without_flags_tuprules() {
+  let contents = String::from(
+".gitignore
+CC = g++
+ARCH = -m64
+CFLAGS += $(ARCH)
+LINKFLAGS += $(ARCH)
+SOURCE = src
+TARGET = target
+SOURCE_TARGET = $(TARGET)
+SOURCE_FILES = $(SOURCE)/*.cpp
+SOURCE_OBJ_FILES = $(SOURCE_TARGET)/*.o
+
+TEST = test
+TEST_TARGET = $(TEST)/$(TARGET)
+TEST_FILES = $(TEST)/$(SOURCE)/*.cpp
+TEST_OBJ_FILES = $(TEST_TARGET)/*.o
+
+# macros
+!compile = |> $(CC) $(CFLAGS) %f -o %o |>
+!archive = |> ar crs %o %f |>
+!link = |> $(CC) $(LINKFLAGS) %f -o %o |>
+
+# includes the STATIC and SHARED variables for the target platform
+include @(TUP_PLATFORM).tup");
+
+  let config = BuildConfig::new(ProjectKind::Binary,
+                                String::from("g++"),
+                                Vec::new(),
+                                Vec::new(),
                                 Arch::X64,
                                 Target::Release);
+
+  let tuprules = Tuprules::new(&config);
+
+  assert_eq!(contents, tuprules.to_string());
+}
+
+#[test]
+fn build_binary_x86_debug_with_flags_tuprules() {
+  let contents = String::from(
+".gitignore
+CC = g++
+CFLAGS += -g
+ARCH = -m32
+CFLAGS += $(ARCH)
+CFLAGS += -c --std=c++1z
+LINKFLAGS += $(ARCH)
+LINKFLAGS += -v
+SOURCE = src
+TARGET = target
+SOURCE_TARGET = $(TARGET)
+SOURCE_FILES = $(SOURCE)/*.cpp
+SOURCE_OBJ_FILES = $(SOURCE_TARGET)/*.o
+
+TEST = test
+TEST_TARGET = $(TEST)/$(TARGET)
+TEST_FILES = $(TEST)/$(SOURCE)/*.cpp
+TEST_OBJ_FILES = $(TEST_TARGET)/*.o
+
+# macros
+!compile = |> $(CC) $(CFLAGS) %f -o %o |>
+!archive = |> ar crs %o %f |>
+!link = |> $(CC) $(LINKFLAGS) %f -o %o |>
+
+# includes the STATIC and SHARED variables for the target platform
+include @(TUP_PLATFORM).tup");
+
+  let config = BuildConfig::new(ProjectKind::Binary,
+                                String::from("g++"),
+                                vec![String::from("-c"), String::from("--std=c++1z")],
+                                vec![String::from("-v")],
+                                Arch::X86,
+                                Target::Debug);
 
   let tuprules = Tuprules::new(&config);
 

--- a/hatch/src/assets/tupfile.rs
+++ b/hatch/src/assets/tupfile.rs
@@ -1,8 +1,18 @@
-pub struct Tupfile;
+use project::{ ProjectKind, LibraryKind };
+
+pub struct Tupfile {
+  kind: ProjectKind
+}
 
 impl Tupfile {
-  pub fn new() -> Tupfile {
-    Tupfile
+  pub fn new(kind: &ProjectKind) -> Tupfile {
+    let copy_kind = match *kind {
+      ProjectKind::Binary => ProjectKind::Binary,
+      ProjectKind::Library(LibraryKind::Static) => ProjectKind::Library(LibraryKind::Static),
+      ProjectKind::Library(LibraryKind::Shared) => ProjectKind::Library(LibraryKind::Shared)
+    };
+
+    Tupfile { kind: copy_kind }
   }
 
   pub fn name() -> String {
@@ -12,25 +22,35 @@ impl Tupfile {
 
 impl ToString for Tupfile {
   fn to_string(&self) -> String {
-    String::from(
-"include config.tup
-include_rules
+    let mut tokens = Vec::new();
 
-# override build variables
-# VARIABLE = new_value
+    let includes = String::from("include config.tup\ninclude_rules\n");
+    let compile_source = String::from(": foreach $(SOURCE_FILES) |> !compile |> $(SOURCE_TARGET)/%B.o\n");
+    let compile_tests = String::from(": foreach $(TEST_FILES) |> !compile |> $(TEST_TARGET)/%B.o\n");
 
-# define custom build variables
+    tokens.push(includes);
+    tokens.push(compile_source);
 
-# Compile Source
-: foreach $(SOURCE_FILES) |> !compile |> $(SOURCE_TARGET)/%B.o
+    match self.kind {
+      ProjectKind::Binary => {
+        tokens.push(String::from(": $(SOURCE_OBJ_FILES) |> !link |> $(SOURCE_TARGET)/$(PROJECT)\n"));
+      },
+      ProjectKind::Library(_) => {
+        tokens.push(String::from(": $(SOURCE_OBJ_FILES) |> !archive |> $(SOURCE_TARGET)/$(PROJECT_LIB) <$(PROJECT)>\n"));
+      }
+    }
 
-# Archive Source
-: $(SOURCE_OBJ_FILES) |> !archive |> $(SOURCE_TARGET)/$(PROJECT_LIB) <$(PROJECT)>
+    tokens.push(compile_tests);
 
-# Compile Tests
-: foreach $(TEST_FILES) |> !compile |> $(TEST_TARGET)/%B.o
+    match self.kind {
+      ProjectKind::Binary => {
+        tokens.push(String::from(": $(TEST_OBJ_FILES) |> !link |> $(TEST_TARGET)/$(PROJECT).test"));
+      },
+      ProjectKind::Library(_) => {
+        tokens.push(String::from(": $(TEST_OBJ_FILES) $(SOURCE_TARGET)/$(PROJECT_LIB) |> !link |> $(TEST_TARGET)/$(PROJECT).test"));
+      }
+    }
 
-# Create Link Executable
-: $(TEST_OBJ_FILES) $(SOURCE_TARGET)/$(PROJECT_LIB) |> !link |> $(TEST_TARGET)/$(PROJECT).test")
+    tokens.iter().map(|token| token.as_str()).collect::<Vec<_>>().join("\n")
   }
 }

--- a/hatch/src/assets/tuprules.rs
+++ b/hatch/src/assets/tuprules.rs
@@ -19,7 +19,7 @@ impl Tuprules {
 
     let copy_arch = match *config.arch() {
       Arch::X64 => Arch::X64,
-      Arch::X32 => Arch::X32
+      Arch::X86 => Arch::X86
     };
 
     let copy_target = match *config.target() {
@@ -44,7 +44,7 @@ impl Tuprules {
   fn arch_flag(arch: &Arch) -> String {
     match *arch {
       Arch::X64 => String::from("-m64"),
-      Arch::X32 => String::from("-m32"),
+      Arch::X86 => String::from("-m32"),
     }
   }
 
@@ -77,12 +77,18 @@ impl ToString for Tuprules {
     tokens.push(arch_token);
 
     tokens.push(String::from("CFLAGS += $(ARCH)"));
-    let compiler_flags = format!("CFLAGS += {}", self.compiler_flags);
-    tokens.push(compiler_flags);
+
+    if !self.compiler_flags.is_empty() {
+      let compiler_flags = format!("CFLAGS += {}", self.compiler_flags);
+      tokens.push(compiler_flags);
+    }
 
     tokens.push(String::from("LINKFLAGS += $(ARCH)"));
-    let linker_flags = format!("LINKFLAGS += {}", self.linker_flags);
-    tokens.push(linker_flags);
+
+    if !self.linker_flags.is_empty() {
+      let linker_flags = format!("LINKFLAGS += {}", self.linker_flags);
+      tokens.push(linker_flags);
+    }
 
     match self.kind {
       ProjectKind::Library(ref lib_kind) => {
@@ -104,28 +110,34 @@ TARGET = target
 SOURCE_TARGET = $(TARGET)
 SOURCE_FILES = $(SOURCE)/*.cpp
 SOURCE_OBJ_FILES = $(SOURCE_TARGET)/*.o
+
 TEST = test
 TEST_TARGET = $(TEST)/$(TARGET)
 TEST_FILES = $(TEST)/$(SOURCE)/*.cpp
 TEST_OBJ_FILES = $(TEST_TARGET)/*.o
+
 # macros
 !compile = |> $(CC) $(CFLAGS) %f -o %o |>
 !archive = |> ar crs %o %f |>
 !link = |> $(CC) $(LINKFLAGS) %f -o %o |>
+
 # includes the STATIC and SHARED variables for the target platform
-include @(TUP_PLATFORM).tup
-ifeq ($(LIB_TYPE),static)
+include @(TUP_PLATFORM).tup"));
+
+    match self.kind {
+      ProjectKind::Library(ref _lib_kind) => {
+        tokens.push(String::from(
+"ifeq ($(LIB_TYPE),static)
   EXTENSION = $(STATIC)
 else
   ifeq ($(LIB_TYPE),shared)
     EXTENSION = $(SHARED)
-  else
-    ifeq ($(LIB_TYPE),both)
-      EXTENSION = both
-    endif
   endif
 endif
 PROJECT_LIB = $(PROJECT).$(EXTENSION)"));
+      },
+      _ => {}
+    }
 
     tokens.iter().map(|token| token.as_str()).collect::<Vec<_>>().join("\n")
   }

--- a/hatch/src/project.rs
+++ b/hatch/src/project.rs
@@ -72,7 +72,7 @@ impl fmt::Display for ProjectKind {
 }
 
 #[derive(Debug)]
-pub enum Arch { X64, X32 }
+pub enum Arch { X64, X86 }
 
 impl AsRef<Arch> for Arch {
   fn as_ref(&self) -> &Arch {
@@ -84,7 +84,7 @@ impl fmt::Display for Arch {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match *self {
       Arch::X64 => write!(f, "x64"),
-      Arch::X32 => write!(f, "x32"),
+      Arch::X86 => write!(f, "x86"),
     }
   }
 }

--- a/hatch/src/task.rs
+++ b/hatch/src/task.rs
@@ -37,7 +37,7 @@ pub fn platform_type() -> PlatformKind {
 
 pub fn architecture() -> Option<Arch> {
   match size_of::<&char>() {
-    32 => Some(Arch::X32),
+    32 => Some(Arch::X86),
     64 => Some(Arch::X64),
     _ => None
   }

--- a/hatch/src/yaml.rs
+++ b/hatch/src/yaml.rs
@@ -90,8 +90,8 @@ pub fn parse(path: &Path, name: String) -> HatchResult<Project> {
             "x64" => {
               arch =Arch::X64
             },
-            "x32" => {
-              arch = Arch::X32
+            "x86" => {
+              arch = Arch::X86
             },
             _ => {
               // use default


### PR DESCRIPTION
- Hatch is now capable of generating binary project versions of its assets.
- Added more robust test cases.
- Cleaned up asset tests.
- Switch Arch::X32 to Arch::X86.