### PR TITLE
Issue58 robust deps

### DIFF
--- a/hatch/src/deps/dependency.rs
+++ b/hatch/src/deps/dependency.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::ffi::OsString;
+use std::ffi::OsStr;
 use std::fmt;
 
 #[derive(Debug)]
@@ -11,15 +11,9 @@ pub struct Dependency {
 impl Dependency {
   pub fn new(url: String) -> Dependency {
     Dependency {
-      name: PathBuf::from(OsString::from(url.clone()))
-        .components()
-        .last()
-        .unwrap()
-        .as_os_str()
-        .to_string_lossy()
-        .into_owned()
-        .as_str()
-        .replace(".git", ""),
+      name: (|u: &OsStr| -> String {
+        String::from(u.to_string_lossy())[..].replace(".git", "")
+      })(PathBuf::from(url.clone()).iter().last().unwrap()),
       url,
     }
   }

--- a/hatch/src/deps/dependency.rs
+++ b/hatch/src/deps/dependency.rs
@@ -19,7 +19,7 @@ impl Dependency {
   fn extract_name(url: String) -> String {
     let url_path = PathBuf::from(url);
     let last_element = url_path.iter().last().unwrap();
-    (last_element.as_ref() as &OsStr).to_string_lossy()[..].replace(".git", "")
+    last_element.to_string_lossy()[..].replace(".git", "")
   }
   
   pub fn name(&self) -> &str {

--- a/hatch/src/deps/dependency.rs
+++ b/hatch/src/deps/dependency.rs
@@ -11,15 +11,19 @@ pub struct Dependency {
 impl Dependency {
   pub fn new(url: String) -> Dependency {
     Dependency {
-      name: Dependency::extract_name(url.clone()),
+      name: Dependency::without_dot_git(Dependency::extract_name(url.clone())),
       url,
     }
+  }
+
+  fn without_dot_git(name: String) -> String {
+    name[..].replace(".git", "")
   }
 
   fn extract_name(url: String) -> String {
     let url_path = PathBuf::from(url);
     let last_element = url_path.iter().last().unwrap();
-    last_element.to_string_lossy()[..].replace(".git", "")
+    last_element.to_string_lossy().into()
   }
   
   pub fn name(&self) -> &str {

--- a/hatch/src/deps/dependency.rs
+++ b/hatch/src/deps/dependency.rs
@@ -11,13 +11,17 @@ pub struct Dependency {
 impl Dependency {
   pub fn new(url: String) -> Dependency {
     Dependency {
-      name: (|u: &OsStr| -> String {
-        String::from(u.to_string_lossy())[..].replace(".git", "")
-      })(PathBuf::from(url.clone()).iter().last().unwrap()),
+      name: Dependency::extract_name(url.clone()),
       url,
     }
   }
 
+  fn extract_name(url: String) -> String {
+    let url_path = PathBuf::from(url);
+    let last_element = url_path.iter().last().unwrap();
+    (last_element.as_ref() as &OsStr).to_string_lossy()[..].replace(".git", "")
+  }
+  
   pub fn name(&self) -> &str {
     self.name.as_ref()
   }

--- a/hatch/src/deps/mod.rs
+++ b/hatch/src/deps/mod.rs
@@ -3,11 +3,11 @@ mod tests;
 
 pub mod dependency;
 
-use hatch_error::HatchResult;
+use hatch_error::{ HatchResult, HatchError };
 use git2::Repository;
 use std::collections::HashSet;
 use std::fs;
-use std::path::Path;
+use std::path::{ PathBuf, Path };
 use task;
 use self::dependency::Dependency;
 use locations::hatchfile_path;
@@ -38,6 +38,7 @@ pub fn clone_project_deps(path: &Path,
                           user_defined_deps: &Vec<Dependency>) -> HatchResult<()> 
 {
   let mut visited: HashSet<String> = HashSet::new();
+  let mut errored: Vec<HatchError> = Vec::new();
 
   // All dependencies are cloned into here
   let registry = &path;
@@ -59,25 +60,39 @@ pub fn clone_project_deps(path: &Path,
     let hatchfile = hatchfile_path(dir);
 
     if hatchfile.exists() {
-      return clone_nested_project_deps(&registry, &dir, &mut visited);
+      return clone_nested_project_deps(&registry, &dir, &mut errored, &mut visited);
     }
     Ok(true)
   })?;
+
+  if !errored.is_empty() {
+    errored.into_iter().for_each(|e| {
+      println!("ERROR: {}", e)
+    });
+  }
 
   Ok(())
 }
 
 fn clone_nested_project_deps(registry: &Path,
                              path: &Path,
-                             visited: &mut
-                             HashSet<String>) -> HatchResult<bool>
+                             errored: &mut Vec<HatchError>,
+                             visited: &mut HashSet<String>) -> HatchResult<bool>
 {
-  let current_project = task::read_project(path)?;
-  if !visited.contains(&current_project.name().to_owned()) {
-    current_project.deps().iter().for_each(|dep| {
-      clone_dep(&dep.url(), &registry.join(dep.name()).as_path());
-    });
-    let _ = visited.insert(current_project.name().to_owned());
-  }
-  Ok(true)
+    match task::read_project(path) {
+      Err(e) => {
+        errored.push(e);
+        return Ok(true);
+      },
+      Ok(current_project) => {
+
+        if !visited.contains(&current_project.name().to_owned()) {
+          current_project.deps().iter().for_each(|dep| {
+            clone_dep(&dep.url(), &registry.join(dep.name()).as_path());
+          });
+          let _ = visited.insert(current_project.name().to_owned());
+        }
+      }
+    }
+    Ok(true)
 }

--- a/hatch/src/deps/mod.rs
+++ b/hatch/src/deps/mod.rs
@@ -60,7 +60,7 @@ pub fn clone_project_deps(path: &Path,
     let hatchfile = hatchfile_path(dir);
 
     if hatchfile.exists() {
-      return clone_nested_project_deps(&registry, &dir, &mut errored, &mut visited);
+      clone_nested_project_deps(&registry, &dir, &mut errored, &mut visited);
     }
     Ok(true)
   })?;
@@ -77,21 +77,19 @@ pub fn clone_project_deps(path: &Path,
 fn clone_nested_project_deps(registry: &Path,
                              path: &Path,
                              errored: &mut Vec<HatchError>,
-                             visited: &mut HashSet<String>) -> HatchResult<bool>
+                             visited: &mut HashSet<String>)
 {
-    match task::read_project(path) {
-      Err(e) => {
-        errored.push(e);
-        return Ok(true);
-      },
-      Ok(current_project) => {
-        if !visited.contains(&current_project.name().to_owned()) {
-          current_project.deps().iter().for_each(|dep| {
-            clone_dep(&dep.url(), &registry.join(dep.name()).as_path());
-          });
-          let _ = visited.insert(current_project.name().to_owned());
-        }
+  match task::read_project(path) {
+    Err(e) => {
+      errored.push(e);
+    },
+    Ok(current_project) => {
+      if !visited.contains(&current_project.name().to_owned()) {
+        current_project.deps().iter().for_each(|dep| {
+          clone_dep(&dep.url(), &registry.join(dep.name()).as_path());
+        });
+        let _ = visited.insert(current_project.name().to_owned());
       }
     }
-    Ok(true)
+  }
 }

--- a/hatch/src/deps/mod.rs
+++ b/hatch/src/deps/mod.rs
@@ -85,7 +85,6 @@ fn clone_nested_project_deps(registry: &Path,
         return Ok(true);
       },
       Ok(current_project) => {
-
         if !visited.contains(&current_project.name().to_owned()) {
           current_project.deps().iter().for_each(|dep| {
             clone_dep(&dep.url(), &registry.join(dep.name()).as_path());


### PR DESCRIPTION
This PR changes the behavior when parsing dependencies.  

When an parsing error occurs report the error to the user after we have completed processing the remaining dependencies.  

An error in parsing does not cause a failure in the construction of a project.  

This PR also cleans up the Dependency constructor quite a bit.   