### PR TITLE
WIP - Issue94 header only library

### DIFF
--- a/hatch/src/assets/config.rs
+++ b/hatch/src/assets/config.rs
@@ -23,6 +23,7 @@ impl Config {
       ProjectKind::Binary => "binary",
       ProjectKind::Static => "static",
       ProjectKind::Shared => "shared",
+      ProjectKind::HeaderOnly => "header-only",
     };
 
     format!("LIB_TYPE = {}", kind)

--- a/hatch/src/assets/config.rs
+++ b/hatch/src/assets/config.rs
@@ -1,4 +1,4 @@
-use project::{ LibraryKind, ProjectKind };
+use project::ProjectKind;
 
 pub struct Config {
   project: String,
@@ -21,8 +21,8 @@ impl Config {
   pub fn lib_type(project_kind: &ProjectKind) -> String {
     let kind = match *project_kind {
       ProjectKind::Binary => "binary",
-      ProjectKind::Library(LibraryKind::Static) => "static",
-      ProjectKind::Library(LibraryKind::Shared) => "shared"
+      ProjectKind::Static => "static",
+      ProjectKind::Shared => "shared",
     };
 
     format!("LIB_TYPE = {}", kind)

--- a/hatch/src/assets/tests/builder.rs
+++ b/hatch/src/assets/tests/builder.rs
@@ -2,7 +2,7 @@ use assets::builder::Builder as AssetBuilder;
 use assets::{ Asset, ProjectAsset };
 use std::path::PathBuf;
 use assets::tests::fixtures;
-use project::{ ProjectKind, LibraryKind };
+use project::ProjectKind;
 
 #[test]
 fn add_asset() {
@@ -19,7 +19,7 @@ fn add_asset() {
 
 #[test]
 fn build_config_asset() {
-  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
+  let project = fixtures::project(ProjectKind::Static);
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.config(&project);
@@ -32,7 +32,7 @@ fn build_config_asset() {
 
 #[test]
 fn build_test_tupfile_asset() {
-  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
+  let project = fixtures::project(ProjectKind::Static);
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.test_tupfile(&project);
@@ -45,7 +45,7 @@ fn build_test_tupfile_asset() {
 
 #[test]
 fn build_tuprules_asset() {
-  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
+  let project = fixtures::project(ProjectKind::Static);
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.tuprules(&project);
@@ -94,7 +94,7 @@ PROJECT_LIB = $(PROJECT).$(EXTENSION)");
 
 #[test]
 fn build_tupfile_asset() {
-  let project = fixtures::project(ProjectKind::Library(LibraryKind::Shared));
+  let project = fixtures::project(ProjectKind::Shared);
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.tupfile(&project);
@@ -117,7 +117,7 @@ include_rules
 
 #[test]
 fn build_tupfile_ini_asset() {
-  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
+  let project = fixtures::project(ProjectKind::Static);
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.tupfile_ini(&project);
@@ -130,7 +130,7 @@ fn build_tupfile_ini_asset() {
 
 #[test]
 fn build_linux_asset() {
-  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
+  let project = fixtures::project(ProjectKind::Static);
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.linux(&project);
@@ -143,7 +143,7 @@ fn build_linux_asset() {
 
 #[test]
 fn build_macos_asset() {
-  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
+  let project = fixtures::project(ProjectKind::Static);
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.macos(&project);
@@ -156,7 +156,7 @@ fn build_macos_asset() {
 
 #[test]
 fn build_windows_asset() {
-  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
+  let project = fixtures::project(ProjectKind::Static);
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.windows(&project);
@@ -175,7 +175,7 @@ CC = clang++.exe
 
 #[test]
 fn build_catch_definition() {
-  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
+  let project = fixtures::project(ProjectKind::Static);
 
   let asset_builder = AssetBuilder::new();
   let actual_asset = asset_builder.catch_definition(&project);

--- a/hatch/src/assets/tests/config.rs
+++ b/hatch/src/assets/tests/config.rs
@@ -1,16 +1,16 @@
 use assets::config::Config;
-use project::{ LibraryKind, ProjectKind };
+use project::ProjectKind;
 
 #[test]
 fn build_shared_config() {
-  let config = Config::new("Test", &ProjectKind::Library(LibraryKind::Shared));
+  let config = Config::new("Test", &ProjectKind::Shared);
 
   assert_eq!("PROJECT = Test\nLIB_TYPE = shared", config.to_string());
 }
 
 #[test]
 fn build_static_config() {
-  let config = Config::new("Test", &ProjectKind::Library(LibraryKind::Static));
+  let config = Config::new("Test", &ProjectKind::Static);
 
   assert_eq!("PROJECT = Test\nLIB_TYPE = static", config.to_string());
 }

--- a/hatch/src/assets/tests/generator.rs
+++ b/hatch/src/assets/tests/generator.rs
@@ -16,7 +16,7 @@ fn generate_one_without_directories() {
     Ok(mut file) => {
       let mut contents = String::new();
       let result = file.read_to_string(&mut contents);
-      fs::remove_file("./test.test");
+      let _ = fs::remove_file("./test.test");
 
       if let Err(e) = result {
         panic!(e)
@@ -25,7 +25,7 @@ fn generate_one_without_directories() {
       assert_eq!(contents, "test");
     },
     Err(e) => {
-      fs::remove_file("./test.test");
+      let _ = fs::remove_file("./test.test");
       panic!(e)
     }
   }
@@ -43,16 +43,16 @@ fn generate_one_with_directories() {
     Ok(mut file) => {
       let mut contents = String::new();
       let result = file.read_to_string(&mut contents);
-      fs::remove_file("./foo/test.test");
-      fs::remove_dir("./foo/");
+      let _ = fs::remove_file("./foo/test.test");
+      let _ = fs::remove_dir("./foo/");
 
       if let Err(e) = result {
         panic!(e)
       }
     },
     Err(e) => {
-      fs::remove_file("./foo/test.test");
-      fs::remove_dir("./foo/");
+      let _ = fs::remove_file("./foo/test.test");
+      let _ = fs::remove_dir("./foo/");
       panic!(e)
     }
   }
@@ -71,7 +71,7 @@ fn generate_one_overwrites_file() {
     Ok(mut file) => {
       let mut contents = String::new();
       let result = file.read_to_string(&mut contents);
-      fs::remove_file("./test2.test");
+      let _ = fs::remove_file("./test2.test");
 
       if let Err(e) = result {
         panic!(e)
@@ -80,7 +80,7 @@ fn generate_one_overwrites_file() {
       assert_eq!(contents, "old");
     },
     Err(e) => {
-      fs::remove_file("./test2.test");
+      let _ = fs::remove_file("./test2.test");
       panic!(e)
     }
   }
@@ -88,7 +88,7 @@ fn generate_one_overwrites_file() {
   let test_asset = ProjectAsset::new(PathBuf::from("./"), String::from("test2.test"), String::from("new"));
 
   if let Err(e) = generate_one(&test_asset) {
-    fs::remove_file("./test2.test");
+    let _ = fs::remove_file("./test2.test");
     panic!(e);
   }
 
@@ -97,7 +97,7 @@ fn generate_one_overwrites_file() {
     Ok(mut file) => {
       let mut contents = String::new();
       let result = file.read_to_string(&mut contents);
-      fs::remove_file("./test2.test");
+      let _ = fs::remove_file("./test2.test");
 
       if let Err(e) = result {
         panic!(e)
@@ -106,7 +106,7 @@ fn generate_one_overwrites_file() {
       assert_eq!(contents, "new");
     },
     Err(e) => {
-      fs::remove_file("./test2.test");
+      let _ = fs::remove_file("./test2.test");
       panic!(e)
     }
   }
@@ -120,8 +120,8 @@ fn generate_all_assets() {
   let test_assets = vec![test_asset_one, test_asset_two];
 
   if let Err(e) = generate_all(&test_assets) {
-    fs::remove_file("./one.test");
-    fs::remove_file("./two.test");
+    let _ = fs::remove_file("./one.test");
+    let _ = fs::remove_file("./two.test");
     panic!(e);
   }
 
@@ -129,18 +129,18 @@ fn generate_all_assets() {
     Ok(mut file) => {
       let mut contents = String::new();
       let result = file.read_to_string(&mut contents);
-      fs::remove_file("./one.test");
+      let _ = fs::remove_file("./one.test");
 
       if let Err(e) = result {
-        fs::remove_file("./two.test");
+        let _ = fs::remove_file("./two.test");
         panic!(e)
       }
     
       assert_eq!(contents, "one");
     },
     Err(e) => {
-      fs::remove_file("./one.test");
-      fs::remove_file("./two.test");
+      let _ = fs::remove_file("./one.test");
+      let _ = fs::remove_file("./two.test");
       panic!(e)
     }
   }
@@ -149,7 +149,7 @@ fn generate_all_assets() {
     Ok(mut file) => {
       let mut contents = String::new();
       let result = file.read_to_string(&mut contents);
-      fs::remove_file("./two.test");
+      let _ = fs::remove_file("./two.test");
 
       if let Err(e) = result {
         panic!(e)
@@ -158,7 +158,7 @@ fn generate_all_assets() {
       assert_eq!(contents, "two");
     },
     Err(e) => {
-      fs::remove_file("./two.test");
+      let _ = fs::remove_file("./two.test");
       panic!(e)
     }
   }

--- a/hatch/src/assets/tests/tupfile.rs
+++ b/hatch/src/assets/tests/tupfile.rs
@@ -1,10 +1,10 @@
 use assets::tupfile::Tupfile;
 use assets::tests::fixtures;
-use project::{ ProjectKind, LibraryKind };
+use project::ProjectKind;
 
 #[test]
 fn build_library_tupfile() {
-  let project = fixtures::project(ProjectKind::Library(LibraryKind::Static));
+  let project = fixtures::project(ProjectKind::Static);
 
   let contents = String::from(
 "include config.tup

--- a/hatch/src/assets/tests/tuprules.rs
+++ b/hatch/src/assets/tests/tuprules.rs
@@ -1,5 +1,5 @@
 use assets::tuprules::Tuprules;
-use project::{ ProjectKind, LibraryKind };
+use project::ProjectKind;
 use project::build::{ Target, Config };
 use platform::arch::Arch;
 
@@ -61,7 +61,7 @@ else
 endif
 PROJECT_LIB = $(PROJECT).$(EXTENSION)");
 
-  let config = Config::new(ProjectKind::Library(LibraryKind::Static),
+  let config = Config::new(ProjectKind::Static,
                            String::from("g++"),
                            vec![String::from("-c"), String::from("--std=c++1z")],
                            vec![String::from("-v")],
@@ -111,7 +111,7 @@ else
   endif
 endif
 PROJECT_LIB = $(PROJECT).$(EXTENSION)");
-  let config = Config::new(ProjectKind::Library(LibraryKind::Static),
+  let config = Config::new(ProjectKind::Static,
                            String::from("g++"),
                            Vec::new(),
                            Vec::new(),
@@ -162,7 +162,7 @@ else
 endif
 PROJECT_LIB = $(PROJECT).$(EXTENSION)");
 
-  let config = Config::new(ProjectKind::Library(LibraryKind::Shared),
+  let config = Config::new(ProjectKind::Shared,
                            String::from("g++"),
                            Vec::new(),
                            Vec::new(),
@@ -214,7 +214,7 @@ else
 endif
 PROJECT_LIB = $(PROJECT).$(EXTENSION)");
 
-  let config = Config::new(ProjectKind::Library(LibraryKind::Shared),
+  let config = Config::new(ProjectKind::Shared,
                            String::from("g++"),
                            vec![String::from("-c"), String::from("--std=c++1z")],
                            vec![String::from("-v")],

--- a/hatch/src/assets/tupfile.rs
+++ b/hatch/src/assets/tupfile.rs
@@ -1,4 +1,4 @@
-use project::{ ProjectKind, LibraryKind };
+use project::ProjectKind;
 
 pub struct Tupfile {
   kind: ProjectKind
@@ -6,13 +6,7 @@ pub struct Tupfile {
 
 impl Tupfile {
   pub fn new(kind: &ProjectKind) -> Tupfile {
-    let copy_kind = match *kind {
-      ProjectKind::Binary => ProjectKind::Binary,
-      ProjectKind::Library(LibraryKind::Static) => ProjectKind::Library(LibraryKind::Static),
-      ProjectKind::Library(LibraryKind::Shared) => ProjectKind::Library(LibraryKind::Shared)
-    };
-
-    Tupfile { kind: copy_kind }
+    Tupfile { kind: kind.clone() }
   }
 
   pub fn name() -> String {
@@ -35,9 +29,10 @@ impl ToString for Tupfile {
       ProjectKind::Binary => {
         tokens.push(String::from(": $(SOURCE_OBJ_FILES) |> !link |> $(SOURCE_TARGET)/$(PROJECT)\n"));
       },
-      ProjectKind::Library(_) => {
+      ProjectKind::Static | ProjectKind::Shared => {
         tokens.push(String::from(": $(SOURCE_OBJ_FILES) |> !archive |> $(SOURCE_TARGET)/$(PROJECT_LIB) <$(PROJECT)>\n"));
-      }
+      },
+      _ => ()
     }
 
     tokens.push(compile_tests);
@@ -46,9 +41,10 @@ impl ToString for Tupfile {
       ProjectKind::Binary => {
         tokens.push(String::from(": $(TEST_OBJ_FILES) |> !link |> $(TEST_TARGET)/$(PROJECT).test"));
       },
-      ProjectKind::Library(_) => {
+      ProjectKind::Static | ProjectKind::Shared => {
         tokens.push(String::from(": $(TEST_OBJ_FILES) $(SOURCE_TARGET)/$(PROJECT_LIB) |> !link |> $(TEST_TARGET)/$(PROJECT).test"));
-      }
+      },
+      _ => ()
     }
 
     tokens.iter().map(|token| token.as_str()).collect::<Vec<_>>().join("\n")

--- a/hatch/src/cli/commands/mod.rs
+++ b/hatch/src/cli/commands/mod.rs
@@ -15,6 +15,7 @@ static TYPE: &str = "TYPE";
 static BIN: &str = "bin";
 static STATIC: &str = "static";
 static SHARED: &str = "shared";
+static HEADER: &str = "header-only";
 static PROJECT_NAME: &str = "PROJECT_NAME";
 static PROJECT_NAMES: &str = "PROJECT_NAMES";
 static PROJECT_PATH: &str = "PROJECT_PATH";

--- a/hatch/src/cli/commands/new.rs
+++ b/hatch/src/cli/commands/new.rs
@@ -2,7 +2,7 @@ use std::fs;
 use clap::{ App, SubCommand, Arg, ArgMatches };
 use cli::commands::{ Command, parse_deps_from_cli };
 use deps::clone_project_deps;
-use project::{ Project, ProjectKind, LibraryKind };
+use project::{ Project, ProjectKind };
 use project::build::{ Target, Config };
 use platform::arch::Arch;
 use deps::dependency::Dependency;
@@ -43,12 +43,12 @@ impl<'new> New {
       // Rust to pattern match on a static variable
       match type_arg.as_str() {
         arg if arg == BIN => ProjectKind::Binary,
-        arg if arg == STATIC => ProjectKind::Library(LibraryKind::Static),
-        arg if arg == SHARED => ProjectKind::Library(LibraryKind::Shared),
-        _ => ProjectKind::Library(LibraryKind::Static)
+        arg if arg == STATIC => ProjectKind::Static,
+        arg if arg == SHARED => ProjectKind::Shared,
+        _ => ProjectKind::Static,
       }
     } else {
-      ProjectKind::Library(LibraryKind::Static)
+      ProjectKind::Static
     }
   }
 

--- a/hatch/src/cli/commands/new.rs
+++ b/hatch/src/cli/commands/new.rs
@@ -122,7 +122,7 @@ impl<'command> Command<'command> for New {
            .help("Determines the type of the project")
            .long("type").short("t")
            .takes_value(true)
-           .possible_values(&[BIN, STATIC, SHARED])
+           .possible_values(&[BIN, STATIC, SHARED, &HEADER])
            .required(true))
 
       .arg(Arg::with_name(VERSION)

--- a/hatch/src/cli/commands/new.rs
+++ b/hatch/src/cli/commands/new.rs
@@ -14,7 +14,7 @@ use task;
 use std::fmt::Write as FmtWrite;
 use std::io::Write as IoWrite;
 
-use cli::commands::{ INCLUDE, VERSION, TYPE, BIN, STATIC, SHARED, PROJECT_NAME };
+use cli::commands::{ INCLUDE, VERSION, TYPE, BIN, STATIC, SHARED, HEADER, PROJECT_NAME };
 
 pub struct New {
   name: &'static str,
@@ -45,6 +45,7 @@ impl<'new> New {
         arg if arg == BIN => ProjectKind::Binary,
         arg if arg == STATIC => ProjectKind::Static,
         arg if arg == SHARED => ProjectKind::Shared,
+        arg if arg == HEADER => ProjectKind::HeaderOnly,
         _ => ProjectKind::Static,
       }
     } else {
@@ -186,10 +187,16 @@ impl<'command> Command<'command> for New {
                                  project_deps,
                                  dir_path.to_owned());
 
-      println!("Generating assets...");
-      task::generate_assets(&project)?;
-
-      println!("Finished");
+      match project.config().kind() {
+        ProjectKind::HeaderOnly => {
+          println!("Skipping tup file generation because project is header-only.");
+        }
+        _ => {
+          println!("Generating assets...");
+          task::generate_assets(&project)?;
+          println!("Finished");
+        }
+      }
 
       Ok(())
     })().with_context(|e| {

--- a/hatch/src/cli/commands/new.rs
+++ b/hatch/src/cli/commands/new.rs
@@ -187,7 +187,7 @@ impl<'command> Command<'command> for New {
                                  project_deps,
                                  dir_path.to_owned());
 
-      match project.config().kind() {
+      match *project.config().kind() {
         ProjectKind::HeaderOnly => {
           println!("Skipping tup file generation because project is header-only.");
         }

--- a/hatch/src/deps/dependency.rs
+++ b/hatch/src/deps/dependency.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::ffi::OsStr;
 use std::fmt;
 
 #[derive(Debug)]

--- a/hatch/src/deps/mod.rs
+++ b/hatch/src/deps/mod.rs
@@ -7,13 +7,13 @@ use hatch_error::{ HatchResult, HatchError };
 use git2::Repository;
 use std::collections::HashSet;
 use std::fs;
-use std::path::{ PathBuf, Path };
+use std::path::Path;
 use task;
 use self::dependency::Dependency;
 use locations::hatchfile_path;
 
 pub fn clone_dep(url: &str, path: &Path) {
-  Repository::clone(url, path);
+  let _ = Repository::clone(url, path);
 }
 
 fn walk(path: &Path,

--- a/hatch/src/project/mod.rs
+++ b/hatch/src/project/mod.rs
@@ -51,11 +51,8 @@ impl Project {
   }
 }
 
-#[derive(Debug)]
-pub enum LibraryKind { Shared, Static }
-
-#[derive(Debug)]
-pub enum ProjectKind { Binary, Library(LibraryKind) }
+#[derive(Debug, Clone, Copy)]
+pub enum ProjectKind { Binary, Static, Shared, HeaderOnly }
 
 impl AsRef<ProjectKind> for ProjectKind {
   fn as_ref(&self) -> &ProjectKind {
@@ -66,8 +63,8 @@ impl AsRef<ProjectKind> for ProjectKind {
 impl fmt::Display for ProjectKind {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match *self {
-      ProjectKind::Library(LibraryKind::Shared) => write!(f, "shared-lib"),
-      ProjectKind::Library(LibraryKind::Static) => write!(f, "static-lib"),
+      ProjectKind::Shared => write!(f, "shared-lib"),
+      ProjectKind::Static => write!(f, "static-lib"),
       ProjectKind::Binary => write!(f, "binary"),
     }
   }

--- a/hatch/src/project/mod.rs
+++ b/hatch/src/project/mod.rs
@@ -66,6 +66,7 @@ impl fmt::Display for ProjectKind {
       ProjectKind::Shared => write!(f, "shared-lib"),
       ProjectKind::Static => write!(f, "static-lib"),
       ProjectKind::Binary => write!(f, "binary"),
+      ProjectKind::HeaderOnly => write!(f, "header-only"),
     }
   }
 }

--- a/hatch/src/task/tests.rs
+++ b/hatch/src/task/tests.rs
@@ -25,13 +25,13 @@ fn assets_exist(path: &Path) -> bool {
 }
 
 fn remove_assets(path: &Path) {
-  fs::remove_dir_all(&path);
+  let _ = fs::remove_dir_all(&path);
 }
 
 #[test]
 fn generate_assets_success() {
   let path = PathBuf::from("./temp/");
-  fs::create_dir_all(&path);
+  let _ = fs::create_dir_all(&path);
 
   let config = Config::new(ProjectKind::Binary,
                            String::from("g++"),

--- a/hatch/src/yaml.rs
+++ b/hatch/src/yaml.rs
@@ -68,6 +68,7 @@ pub fn parse(path: &Path, name: String) -> HatchResult<Project> {
             "static-lib" => ProjectKind::Static,
             "shared-lib" => ProjectKind::Shared,
             "binary" => ProjectKind::Binary,
+            "header-only" => ProjectKind::HeaderOnly,
             _ => ProjectKind::Static
           }
         },

--- a/hatch/src/yaml.rs
+++ b/hatch/src/yaml.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::io::Read;
 use std::path::{ Path, PathBuf };
 use yaml_rust::{ Yaml, YamlLoader };
-use project::{ Project, LibraryKind, ProjectKind };
+use project::{ Project, ProjectKind };
 use project::build::{ Target, Config };
 use deps::dependency::Dependency;
 use platform::arch::Arch;
@@ -25,7 +25,7 @@ pub fn parse(path: &Path, name: String) -> HatchResult<Project> {
 
   let name: String;
   let version: String;
-  let mut kind: ProjectKind = ProjectKind::Library(LibraryKind::Static);
+  let mut kind: ProjectKind = ProjectKind::Static;
   let mut compiler: String = String::from("g++");
   let mut compiler_flags: Vec<String> = vec![String::from("-c")];
   let mut linker_flags: Vec<String> = vec![String::from("-v")];
@@ -65,9 +65,10 @@ pub fn parse(path: &Path, name: String) -> HatchResult<Project> {
       match key {
         "kind" => {
           kind = match value {
-            "static-lib" => ProjectKind::Library(LibraryKind::Static),
-            "shared-lib" => ProjectKind::Library(LibraryKind::Shared),
-            _ => ProjectKind::Binary
+            "static-lib" => ProjectKind::Static,
+            "shared-lib" => ProjectKind::Shared,
+            "binary" => ProjectKind::Binary,
+            _ => ProjectKind::Static
           }
         },
         "compiler" => {


### PR DESCRIPTION
This PR makes room for header-only libraries.

Most work in this PR is coercing the ProjectKind enum and eliminating the LibraryEnum to better express logic. The LibraryKind enum is not one that will be extended often, and it added some cognitive overhead. ProjectKind is now a copyable enum which and is the only enum needed for determing how to build assets.

The HeaderOnly variant is added. Header-only libraries do not need compilation, so no tup files should be generated. There is now a match on the ProjectKind before generating assets.

- [x] Add HeaderOnly ProjectKind
- [x] Add CLI support for header-only library type
- [ ] Don't output all compiler options in Hatch.yml when building HeaderOnly