### PR TITLE
Update the command interface to take a Generator

### DIFF
--- a/hatch/src/assets/builder.rs
+++ b/hatch/src/assets/builder.rs
@@ -1,127 +1,129 @@
-use assets::{PlatformKind, ProjectAsset, TupKind};
+use assets::catch_definition::CatchDefinition;
+use assets::catch_header::CatchHeader;
 use assets::config::Config;
-use assets::tuprules::Tuprules;
+use assets::platform::{Linux, MacOS, Windows};
 use assets::test_tupfile::Tupfile as TestTupfile;
 use assets::tupfile::Tupfile;
-use assets::platform::{Linux, MacOS, Windows};
 use assets::tupfile_ini::TupfileIni;
-use assets::catch_header::CatchHeader;
-use assets::catch_definition::CatchDefinition;
-use hatch_error::{ HatchResult, ResultExt, NullError };
-use reqwest;
-use project::Project;
+use assets::tuprules::Tuprules;
+use assets::{PlatformKind, ProjectAsset, TupKind};
 use constants::CATCH_HEADER_URL;
+use hatch_error::{HatchResult, NullError, ResultExt};
+use project::Project;
+use reqwest;
 use std::path::PathBuf;
 
 pub struct Builder<'builder> {
-  project_path: PathBuf,
-  project: &'builder Project,
-  pub assets: Vec<ProjectAsset>
+    project_path: PathBuf,
+    project: &'builder Project,
+    pub assets: Vec<ProjectAsset>,
 }
 
 impl<'builder> Builder<'builder> {
-  pub fn new(project_path: PathBuf, project: &'builder Project) -> Builder<'builder> {
-    Builder { project_path, project, assets: Vec::new() }
-  }
+    pub fn new(project_path: PathBuf, project: &'builder Project) -> Builder<'builder> {
+        Builder {
+            project_path,
+            project,
+            assets: Vec::new(),
+        }
+    }
 
-  pub fn collect_assets(builder: Builder) -> Vec<ProjectAsset> {
-    builder.assets
-  }
+    pub fn collect_assets(builder: Builder) -> Vec<ProjectAsset> {
+        builder.assets
+    }
 
-  pub fn add_asset(&mut self, asset: ProjectAsset) {
-    self.assets.push(asset);
-  }
+    pub fn add_asset(&mut self, asset: ProjectAsset) {
+        self.assets.push(asset);
+    }
 
-  pub fn project(&mut self, asset_kind: TupKind) {
-
-    let asset = match asset_kind {
-      TupKind::Config => self.config(),
-      TupKind::TestTupfile => self.test_tupfile(),
-      TupKind::Tuprules => self.tuprules(),
-      TupKind::Tupfile => self.tupfile(),
-      TupKind::TupfileIni => self.tupfile_ini(),
-    };
-
-    self.assets.push(asset);
-  }
-
-  pub fn platform(&mut self, asset_kind: &PlatformKind) {
-    let asset = match *asset_kind {
-      PlatformKind::Linux => self.linux(),
-      PlatformKind::MacOS => self.macos(),
-      PlatformKind::Windows => self.windows()
-    };
+    pub fn project(&mut self, asset_kind: TupKind) {
+        let asset = match asset_kind {
+            TupKind::Config => self.config(),
+            TupKind::TestTupfile => self.test_tupfile(),
+            TupKind::Tuprules => self.tuprules(),
+            TupKind::Tupfile => self.tupfile(),
+            TupKind::TupfileIni => self.tupfile_ini(),
+        };
 
         self.assets.push(asset);
     }
 
-  pub fn config(&self) -> ProjectAsset {
-    let project_path = self.project_path.clone();
-    let project = &self.project;
-    let contents = Config::new(project.name(), project.kind()).to_string();
-    ProjectAsset::new(project_path, Config::name(), contents)
-  }
+    pub fn platform(&mut self, asset_kind: &PlatformKind) {
+        let asset = match *asset_kind {
+            PlatformKind::Linux => self.linux(),
+            PlatformKind::MacOS => self.macos(),
+            PlatformKind::Windows => self.windows(),
+        };
 
-  pub fn test_tupfile(&self) -> ProjectAsset {
-    let asset_path = self.project_path.join("test");
-    let contents = TestTupfile::new().to_string();
-    ProjectAsset::new(asset_path, TestTupfile::name(), contents)
-  }
+        self.assets.push(asset);
+    }
 
-  pub fn tuprules(&self) -> ProjectAsset {
-    let project_path = self.project_path.clone();
-    let project = &self.project;
-    let tuprules = Tuprules{};
-    let contents = tuprules.to_string(&project);
-    ProjectAsset::new(project_path, Tuprules::name(), contents)
-  }
+    pub fn config(&self) -> ProjectAsset {
+        let project_path = self.project_path.clone();
+        let project = &self.project;
+        let contents = Config::new(project.name(), project.kind()).to_string();
+        ProjectAsset::new(project_path, Config::name(), contents)
+    }
 
-  pub fn tupfile(&self) -> ProjectAsset {
-    let project_path = self.project_path.clone();
-    let project = &self.project;
-    let contents = Tupfile::new(project.kind()).to_string();
-    ProjectAsset::new(project_path, Tupfile::name(), contents)
-  }
+    pub fn test_tupfile(&self) -> ProjectAsset {
+        let asset_path = self.project_path.join("test");
+        let contents = TestTupfile::new().to_string();
+        ProjectAsset::new(asset_path, TestTupfile::name(), contents)
+    }
 
-  pub fn tupfile_ini(&self) -> ProjectAsset {
-    let contents = TupfileIni::new().to_string();
-    let project_path = self.project_path.clone();
-    ProjectAsset::new(project_path, TupfileIni::name(), contents)
-  }
+    pub fn tuprules(&self) -> ProjectAsset {
+        let project_path = self.project_path.clone();
+        let project = &self.project;
+        let tuprules = Tuprules {};
+        let contents = tuprules.to_string(&project);
+        ProjectAsset::new(project_path, Tuprules::name(), contents)
+    }
 
-  pub fn linux(&self) -> ProjectAsset {
-    let project_path = self.project_path.clone();
-    let contents = Linux::new().to_string();
-    ProjectAsset::new(project_path, Linux::name(), contents)
-  }
+    pub fn tupfile(&self) -> ProjectAsset {
+        let project_path = self.project_path.clone();
+        let project = &self.project;
+        let contents = Tupfile::new(project.kind()).to_string();
+        ProjectAsset::new(project_path, Tupfile::name(), contents)
+    }
 
-  pub fn macos(&self) -> ProjectAsset {
-    let project_path = self.project_path.clone();
-    let contents = MacOS::new().to_string();
-    ProjectAsset::new(project_path, MacOS::name(), contents)
-  }
+    pub fn tupfile_ini(&self) -> ProjectAsset {
+        let contents = TupfileIni::new().to_string();
+        let project_path = self.project_path.clone();
+        ProjectAsset::new(project_path, TupfileIni::name(), contents)
+    }
 
-  pub fn windows(&self) -> ProjectAsset {
-    let project_path = self.project_path.clone();
-    let contents = Windows::new().to_string();
-    ProjectAsset::new(project_path, Windows::name(), contents)
-  }
+    pub fn linux(&self) -> ProjectAsset {
+        let project_path = self.project_path.clone();
+        let contents = Linux::new().to_string();
+        ProjectAsset::new(project_path, Linux::name(), contents)
+    }
 
-  pub fn catch_header(&self) -> HatchResult<ProjectAsset> {
-    let test_src_path = self.project_path.join("test/src");
-    let file_name = CatchHeader::name();
-    if !test_src_path.join(file_name).exists() {
-      let res = (|| -> HatchResult<ProjectAsset> {
-        let mut resp = reqwest::get(CATCH_HEADER_URL)?;
-        let content = resp.text()?;
+    pub fn macos(&self) -> ProjectAsset {
+        let project_path = self.project_path.clone();
+        let contents = MacOS::new().to_string();
+        ProjectAsset::new(project_path, MacOS::name(), contents)
+    }
+
+    pub fn windows(&self) -> ProjectAsset {
+        let project_path = self.project_path.clone();
+        let contents = Windows::new().to_string();
+        ProjectAsset::new(project_path, Windows::name(), contents)
+    }
+
+    pub fn catch_header(&self) -> HatchResult<ProjectAsset> {
+        let test_src_path = self.project_path.join("test/src");
+        let file_name = CatchHeader::name();
+        if !test_src_path.join(file_name).exists() {
+            let res = (|| -> HatchResult<ProjectAsset> {
+                let mut resp = reqwest::get(CATCH_HEADER_URL)?;
+                let content = resp.text()?;
 
                 Ok(ProjectAsset::new(
                     test_src_path,
                     CatchHeader::name(),
                     content,
                 ))
-            })()
-                .with_context(|e| format!("failed to generate catch.hpp : {}", e))?;
+            })().with_context(|e| format!("failed to generate catch.hpp : {}", e))?;
 
             Ok(res)
         } else {
@@ -129,9 +131,9 @@ impl<'builder> Builder<'builder> {
         }
     }
 
-  pub fn catch_definition(&self) -> ProjectAsset {
-    let test_src_path = self.project_path.join("test/src");
-    let contents = CatchDefinition::new().to_string();
+    pub fn catch_definition(&self) -> ProjectAsset {
+        let test_src_path = self.project_path.join("test/src");
+        let contents = CatchDefinition::new().to_string();
 
         ProjectAsset::new(test_src_path, CatchDefinition::name(), contents)
     }

--- a/hatch/src/assets/config.rs
+++ b/hatch/src/assets/config.rs
@@ -21,13 +21,13 @@ impl Config {
         format!("PROJECT = {}", name)
     }
 
-  pub fn lib_type(project_kind: &ProjectKind) -> String {
-    let kind = match *project_kind {
-      ProjectKind::Binary => "binary",
-      ProjectKind::Static => "static",
-      ProjectKind::Shared => "shared",
-      ProjectKind::HeaderOnly => "header-only",
-    };
+    pub fn lib_type(project_kind: &ProjectKind) -> String {
+        let kind = match *project_kind {
+            ProjectKind::Binary => "binary",
+            ProjectKind::Static => "static",
+            ProjectKind::Shared => "shared",
+            ProjectKind::HeaderOnly => "header-only",
+        };
 
         format!("LIB_TYPE = {}", kind)
     }

--- a/hatch/src/assets/generator.rs
+++ b/hatch/src/assets/generator.rs
@@ -1,11 +1,15 @@
-use assets::{ ProjectAsset };
-use hatch_error::{ HatchResult, ResultExt };
+use assets::ProjectAsset;
+use hatch_error::{HatchResult, ResultExt};
 
 pub fn generate_all(assets: &Vec<ProjectAsset>) -> HatchResult<()> {
-  for asset in assets {
-    asset.write().with_context(|e| {
-      format!("Failed to generate asset: `{}` : {}", asset.path().display(), e)
-    })?;
-  }
-  Ok(())
+    for asset in assets {
+        asset.write().with_context(|e| {
+            format!(
+                "Failed to generate asset: `{}` : {}",
+                asset.path().display(),
+                e
+            )
+        })?;
+    }
+    Ok(())
 }

--- a/hatch/src/assets/mod.rs
+++ b/hatch/src/assets/mod.rs
@@ -1,22 +1,22 @@
-use std::path::Path;
-use std::path::PathBuf;
-use std::fs;
+use core::cmp;
 use failure::ResultExt;
 use hatch_error::HatchResult;
-use std::io::Write;
-use core::cmp;
 use std::fmt;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
 
 pub mod builder;
-pub mod generator;
-pub mod config;
-pub mod tupfile;
-pub mod platform;
-pub mod tuprules;
-pub mod test_tupfile;
-pub mod tupfile_ini;
-pub mod catch_header;
 pub mod catch_definition;
+pub mod catch_header;
+pub mod config;
+pub mod generator;
+pub mod platform;
+pub mod test_tupfile;
+pub mod tupfile;
+pub mod tupfile_ini;
+pub mod tuprules;
 
 #[cfg(test)]
 mod tests;
@@ -44,45 +44,57 @@ pub struct ProjectAsset {
 }
 
 impl ProjectAsset {
-  pub fn new(path: PathBuf, name: String, contents: String) -> ProjectAsset {
-    ProjectAsset { path, name, contents }
-  }
+    pub fn new(path: PathBuf, name: String, contents: String) -> ProjectAsset {
+        ProjectAsset {
+            path,
+            name,
+            contents,
+        }
+    }
 
     pub fn name(&self) -> &str {
         self.name.as_str()
     }
 
-  pub fn path(& self) -> &Path {
-    self.path.as_path()
-  }
+    pub fn path(&self) -> &Path {
+        self.path.as_path()
+    }
 
-  pub fn write(&self) -> HatchResult<()> {
-    let path = self.path();
-    fs::create_dir_all(path).with_context(|e| {
-    format!("Failed to create directory: `{}` : {}", path.display(), e)
-    })?;
+    pub fn write(&self) -> HatchResult<()> {
+        let path = self.path();
+        fs::create_dir_all(path)
+            .with_context(|e| format!("Failed to create directory: `{}` : {}", path.display(), e))?;
 
-    let file_path = path.join(&self.name);
-    let mut file = fs::File::create(&file_path).with_context(|e| {
-    format!("Failed to create file: `{}` : {}", file_path.display(), e)
-    })?;
+        let file_path = path.join(&self.name);
+        let mut file = fs::File::create(&file_path)
+            .with_context(|e| format!("Failed to create file: `{}` : {}", file_path.display(), e))?;
 
-    file.write_all(self.contents.as_bytes()).with_context(|e| {
-    format!("Failed to write contents to file: `{}` : {}", file_path.display(), e)
-    })?;
+        file.write_all(self.contents.as_bytes()).with_context(|e| {
+            format!(
+                "Failed to write contents to file: `{}` : {}",
+                file_path.display(),
+                e
+            )
+        })?;
 
-    Ok(())
-  }
+        Ok(())
+    }
 }
 
 impl fmt::Debug for ProjectAsset {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(f, "path: {}, name: {}, contents: {}", self.path.display(), self.name, self.contents)
-  }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "path: {}, name: {}, contents: {}",
+            self.path.display(),
+            self.name,
+            self.contents
+        )
+    }
 }
 
 impl cmp::PartialEq for ProjectAsset {
-  fn eq(&self, other: &ProjectAsset) -> bool {
-    self.name == other.name && self.contents == other.contents
-  }
+    fn eq(&self, other: &ProjectAsset) -> bool {
+        self.name == other.name && self.contents == other.contents
+    }
 }

--- a/hatch/src/assets/tests/builder.rs
+++ b/hatch/src/assets/tests/builder.rs
@@ -1,8 +1,8 @@
 use assets::builder::Builder as AssetBuilder;
-use assets::{ProjectAsset};
-use std::path::PathBuf;
 use assets::tests::fixtures;
-use project::{ProjectKind};
+use assets::ProjectAsset;
+use project::ProjectKind;
+use std::path::PathBuf;
 
 #[test]
 fn add_asset() {

--- a/hatch/src/assets/tests/config.rs
+++ b/hatch/src/assets/tests/config.rs
@@ -1,5 +1,5 @@
 use assets::config::Config;
-use project::{ProjectKind};
+use project::ProjectKind;
 
 #[test]
 fn build_shared_config() {

--- a/hatch/src/assets/tests/fixtures.rs
+++ b/hatch/src/assets/tests/fixtures.rs
@@ -1,7 +1,7 @@
-use project::{Project, ProjectKind};
 use platform::arch::Arch;
 use project::CompilerOptions;
 use project::Target;
+use project::{Project, ProjectKind};
 
 pub fn project(kind: ProjectKind) -> Project {
     let compiler_options = CompilerOptions::new(
@@ -23,11 +23,15 @@ pub fn project(kind: ProjectKind) -> Project {
     project
 }
 
-pub fn project_with_compiler_options(kind: ProjectKind, compiler_options: CompilerOptions) -> Project {
+pub fn project_with_compiler_options(
+    kind: ProjectKind,
+    compiler_options: CompilerOptions,
+) -> Project {
     Project::new(
         String::from("test"),
         String::from("0.1.0"),
         kind,
         Some(compiler_options),
-        Vec::new())
+        Vec::new(),
+    )
 }

--- a/hatch/src/assets/tests/mod.rs
+++ b/hatch/src/assets/tests/mod.rs
@@ -1,13 +1,13 @@
 mod builder;
-mod generator;
+mod catch_definition;
+mod catch_header;
 mod config;
+mod fixtures;
+mod generator;
 mod platform;
 mod test_tupfile;
 mod tupfile;
 mod tuprules;
-mod catch_header;
-mod catch_definition;
-mod fixtures;
 
 use assets::ProjectAsset;
 use std::path::PathBuf;

--- a/hatch/src/assets/tests/tupfile.rs
+++ b/hatch/src/assets/tests/tupfile.rs
@@ -1,6 +1,6 @@
-use assets::tupfile::Tupfile;
 use assets::tests::fixtures;
-use project::{ProjectKind};
+use assets::tupfile::Tupfile;
+use project::ProjectKind;
 
 #[test]
 fn build_library_tupfile() {

--- a/hatch/src/assets/tests/tuprules.rs
+++ b/hatch/src/assets/tests/tuprules.rs
@@ -1,9 +1,9 @@
+use assets::tests::fixtures::project_with_compiler_options;
 use assets::tuprules::Tuprules;
 use platform::arch::Arch;
 use project::CompilerOptions;
-use project::Target;
-use assets::tests::fixtures::project_with_compiler_options;
 use project::ProjectKind;
+use project::Target;
 
 /**
 I'm sorry Danny. I have completely destroyed your beautiful, elegant, All-pairs testing strategy.
@@ -69,14 +69,15 @@ endif
 PROJECT_LIB = $(PROJECT).$(EXTENSION)",
     );
 
-  let compiler_options = CompilerOptions::new(
-                           String::from("g++"),
-                           vec![String::from("-c"), String::from("--std=c++1z")].join(' '.to_string().as_str()),
-                           vec![String::from("-v")].join(' '.to_string().as_str()),
-                           Arch::X64,
-                           Target::Release);
+    let compiler_options = CompilerOptions::new(
+        String::from("g++"),
+        vec![String::from("-c"), String::from("--std=c++1z")].join(' '.to_string().as_str()),
+        vec![String::from("-v")].join(' '.to_string().as_str()),
+        Arch::X64,
+        Target::Release,
+    );
 
-    let tuprules = Tuprules{};
+    let tuprules = Tuprules {};
     let project = project_with_compiler_options(ProjectKind::Static, compiler_options);
 
     assert_eq!(contents, tuprules.to_string(&project));
@@ -119,16 +120,18 @@ else
     EXTENSION = $(SHARED)
   endif
 endif
-PROJECT_LIB = $(PROJECT).$(EXTENSION)");
+PROJECT_LIB = $(PROJECT).$(EXTENSION)",
+    );
 
-  let compiler_options = CompilerOptions::new(
-                           String::from("g++"),
-                           String::from(""),
-                           String::from(""),
-                           Arch::X86,
-                           Target::Debug);
+    let compiler_options = CompilerOptions::new(
+        String::from("g++"),
+        String::from(""),
+        String::from(""),
+        Arch::X86,
+        Target::Debug,
+    );
 
-    let tuprules = Tuprules{};
+    let tuprules = Tuprules {};
     let project = project_with_compiler_options(ProjectKind::Static, compiler_options);
 
     assert_eq!(contents, tuprules.to_string(&project));
@@ -174,14 +177,15 @@ endif
 PROJECT_LIB = $(PROJECT).$(EXTENSION)",
     );
 
-  let compiler_options = CompilerOptions::new(
-                           String::from("g++"),
-                           String::from(""),
-                           String::from(""),
-                           Arch::X64,
-                           Target::Debug);
+    let compiler_options = CompilerOptions::new(
+        String::from("g++"),
+        String::from(""),
+        String::from(""),
+        Arch::X64,
+        Target::Debug,
+    );
 
-    let tuprules = Tuprules{};
+    let tuprules = Tuprules {};
     let project = project_with_compiler_options(ProjectKind::Shared, compiler_options);
 
     assert_eq!(contents, tuprules.to_string(&project));
@@ -236,7 +240,7 @@ PROJECT_LIB = $(PROJECT).$(EXTENSION)",
         Target::Release,
     );
 
-    let tuprules = Tuprules{};
+    let tuprules = Tuprules {};
     let project = project_with_compiler_options(ProjectKind::Shared, compiler_options);
 
     assert_eq!(contents, tuprules.to_string(&project));
@@ -278,7 +282,7 @@ include @(TUP_PLATFORM).tup",
         Target::Release,
     );
 
-    let tuprules = Tuprules{};
+    let tuprules = Tuprules {};
     let project = project_with_compiler_options(ProjectKind::Binary, compiler_options);
 
     assert_eq!(contents, tuprules.to_string(&project));
@@ -323,7 +327,7 @@ include @(TUP_PLATFORM).tup",
         Target::Debug,
     );
 
-    let tuprules = Tuprules{};
+    let tuprules = Tuprules {};
     let project = project_with_compiler_options(ProjectKind::Binary, compiler_options);
 
     assert_eq!(contents, tuprules.to_string(&project));
@@ -366,7 +370,7 @@ include @(TUP_PLATFORM).tup",
         Target::Release,
     );
 
-    let tuprules = Tuprules{};
+    let tuprules = Tuprules {};
     let project = project_with_compiler_options(ProjectKind::Binary, compiler_options);
 
     assert_eq!(contents, tuprules.to_string(&project));
@@ -410,7 +414,7 @@ include @(TUP_PLATFORM).tup",
         Target::Debug,
     );
 
-    let tuprules = Tuprules{};
+    let tuprules = Tuprules {};
     let project = project_with_compiler_options(ProjectKind::Binary, compiler_options);
 
     assert_eq!(contents, tuprules.to_string(&project));

--- a/hatch/src/assets/tupfile.rs
+++ b/hatch/src/assets/tupfile.rs
@@ -5,14 +5,13 @@ pub struct Tupfile {
 }
 
 impl Tupfile {
-  pub fn new(kind: &ProjectKind) -> Tupfile {
-    let copy_kind = match *kind {
-      ProjectKind::Binary => ProjectKind::Binary,
-      ProjectKind::Static => ProjectKind::Static,
-      ProjectKind::Shared => ProjectKind::Shared,
-      ProjectKind::HeaderOnly => ProjectKind::HeaderOnly,
-
-    };
+    pub fn new(kind: &ProjectKind) -> Tupfile {
+        let copy_kind = match *kind {
+            ProjectKind::Binary => ProjectKind::Binary,
+            ProjectKind::Static => ProjectKind::Static,
+            ProjectKind::Shared => ProjectKind::Shared,
+            ProjectKind::HeaderOnly => ProjectKind::HeaderOnly,
+        };
 
         Tupfile { kind: copy_kind }
     }
@@ -24,38 +23,45 @@ impl Tupfile {
 
 impl ToString for Tupfile {
     fn to_string(&self) -> String {
-      let mut tokens = Vec::new();
+        let mut tokens = Vec::new();
 
-      let includes = String::from("include config.tup\ninclude_rules\n");
-      let compile_source =
-        String::from(": foreach $(SOURCE_FILES) |> !compile |> $(SOURCE_TARGET)/%B.o\n");
-      let compile_tests =
-        String::from(": foreach $(TEST_FILES) |> !compile |> $(TEST_TARGET)/%B.o\n");
+        let includes = String::from("include config.tup\ninclude_rules\n");
+        let compile_source =
+            String::from(": foreach $(SOURCE_FILES) |> !compile |> $(SOURCE_TARGET)/%B.o\n");
+        let compile_tests =
+            String::from(": foreach $(TEST_FILES) |> !compile |> $(TEST_TARGET)/%B.o\n");
 
-      tokens.push(includes);
-      tokens.push(compile_source);
+        tokens.push(includes);
+        tokens.push(compile_source);
 
-      match self.kind {
-        ProjectKind::Binary => {
-          tokens.push(String::from(": $(SOURCE_OBJ_FILES) |> !link |> $(SOURCE_TARGET)/$(PROJECT)\n"));
-        },
-        ProjectKind::Static | ProjectKind::Shared => {
-          tokens.push(String::from(": $(SOURCE_OBJ_FILES) |> !archive |> $(SOURCE_TARGET)/$(PROJECT_LIB) <$(PROJECT)>\n"));
+        match self.kind {
+            ProjectKind::Binary => {
+                tokens.push(String::from(
+                    ": $(SOURCE_OBJ_FILES) |> !link |> $(SOURCE_TARGET)/$(PROJECT)\n",
+                ));
+            }
+            ProjectKind::Static | ProjectKind::Shared => {
+                tokens.push(String::from(": $(SOURCE_OBJ_FILES) |> !archive |> $(SOURCE_TARGET)/$(PROJECT_LIB) <$(PROJECT)>\n"));
+            }
+            _ => panic!("should never get here!"),
         }
-        _ => panic!("should never get here!")
-      }
 
-      tokens.push(compile_tests);
+        tokens.push(compile_tests);
 
-      match self.kind {
-        ProjectKind::Binary => tokens.push(String::from(": $(TEST_OBJ_FILES) |> !link |> $(TEST_TARGET)/$(PROJECT).test")),
-        ProjectKind::Static | ProjectKind::Shared => {
-          tokens.push(String::from(": $(TEST_OBJ_FILES) $(SOURCE_TARGET)/$(PROJECT_LIB) |> !link |> $(TEST_TARGET)/$(PROJECT).test"));
-        }
-        _ => panic!("should never get here!")
-      };
+        match self.kind {
+            ProjectKind::Binary => tokens.push(String::from(
+                ": $(TEST_OBJ_FILES) |> !link |> $(TEST_TARGET)/$(PROJECT).test",
+            )),
+            ProjectKind::Static | ProjectKind::Shared => {
+                tokens.push(String::from(": $(TEST_OBJ_FILES) $(SOURCE_TARGET)/$(PROJECT_LIB) |> !link |> $(TEST_TARGET)/$(PROJECT).test"));
+            }
+            _ => panic!("should never get here!"),
+        };
 
-      tokens.iter().map(|token| token.as_str()).collect::<Vec<_>>().join("\n")
-
+        tokens
+            .iter()
+            .map(|token| token.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 }

--- a/hatch/src/assets/tuprules.rs
+++ b/hatch/src/assets/tuprules.rs
@@ -1,88 +1,85 @@
 use platform::arch::Arch;
-use project::Target;
-use project::ProjectKind;
 use project::Project;
+use project::ProjectKind;
+use project::Target;
 
 pub struct Tuprules {}
 
 impl Tuprules {
-  pub fn name() -> String {
-    String::from("Tuprules.tup")
-  }
+    pub fn name() -> String {
+        String::from("Tuprules.tup")
+    }
 
-  fn arch_flag(arch: &Arch) -> String {
+    fn arch_flag(arch: &Arch) -> String {
         match *arch {
             Arch::X64 => String::from("-m64"),
             Arch::X86 => String::from("-m32"),
         }
     }
 
-  fn type_flag(lib_type: &ProjectKind) -> String {
-    match *lib_type {
-      ProjectKind::Static => String::from("-static"),
-      ProjectKind::Shared => String::from("-dynamic"),
-      _ => String::from("")
+    fn type_flag(lib_type: &ProjectKind) -> String {
+        match *lib_type {
+            ProjectKind::Static => String::from("-static"),
+            ProjectKind::Shared => String::from("-dynamic"),
+            _ => String::from(""),
+        }
     }
-  }
 
-  pub fn to_string(&self, project: &Project) -> String {
-    let mut tokens = Vec::new();
-    tokens.push(String::from(".gitignore"));
+    pub fn to_string(&self, project: &Project) -> String {
+        let mut tokens = Vec::new();
+        tokens.push(String::from(".gitignore"));
 
-    let project_kind = project.kind();
-    let maybe_compiler_options = project.compiler_options();
-    let _ = match *maybe_compiler_options {
-      Some(ref compiler_options) => {
-        let compiler_token = format!("CC = {}", compiler_options.compiler());
-        tokens.push(compiler_token);
+        let project_kind = project.kind();
+        let maybe_compiler_options = project.compiler_options();
+        let _ = match *maybe_compiler_options {
+            Some(ref compiler_options) => {
+                let compiler_token = format!("CC = {}", compiler_options.compiler());
+                tokens.push(compiler_token);
 
-        match compiler_options.target() {
-          &Target::Debug => {
-            let debug_token = String::from("CFLAGS += -g");
-            tokens.push(debug_token);
-          },
-          _ => {}
-        }
+                match compiler_options.target() {
+                    &Target::Debug => {
+                        let debug_token = String::from("CFLAGS += -g");
+                        tokens.push(debug_token);
+                    }
+                    _ => {}
+                }
 
-        let arch_flag = Tuprules::arch_flag(compiler_options.arch());
-        let arch_token = format!("ARCH = {}", arch_flag);
-        tokens.push(arch_token);
-        tokens.push(String::from("CFLAGS += $(ARCH)"));
+                let arch_flag = Tuprules::arch_flag(compiler_options.arch());
+                let arch_token = format!("ARCH = {}", arch_flag);
+                tokens.push(arch_token);
+                tokens.push(String::from("CFLAGS += $(ARCH)"));
 
-        if !compiler_options.compiler_flags().is_empty() {
-          let compiler_flags = format!("CFLAGS += {}", compiler_options.compiler_flags());
-          tokens.push(compiler_flags);
-        }
+                if !compiler_options.compiler_flags().is_empty() {
+                    let compiler_flags = format!("CFLAGS += {}", compiler_options.compiler_flags());
+                    tokens.push(compiler_flags);
+                }
 
-        tokens.push(String::from("LINKFLAGS += $(ARCH)"));
+                tokens.push(String::from("LINKFLAGS += $(ARCH)"));
 
-        if !compiler_options.linker_flags().is_empty() {
-          let linker_flags = format!("LINKFLAGS += {}", compiler_options.linker_flags());
-          tokens.push(linker_flags);
-        }
+                if !compiler_options.linker_flags().is_empty() {
+                    let linker_flags = format!("LINKFLAGS += {}", compiler_options.linker_flags());
+                    tokens.push(linker_flags);
+                }
+            }
+            _ => panic!(""),
+        };
 
-
-      },
-      _ => panic!("")
-    };
-
-    match *project_kind {
-      ProjectKind::Static | ProjectKind::Shared => {
-        let link_flags_type = format!(
-          "ifneq (@(TUP_PLATFORM),macosx)
+        match *project_kind {
+            ProjectKind::Static | ProjectKind::Shared => {
+                let link_flags_type = format!(
+                    "ifneq (@(TUP_PLATFORM),macosx)
   LINKFLAGS += {}
-endif", Tuprules::type_flag(project_kind));
+endif",
+                    Tuprules::type_flag(project_kind)
+                );
 
-        tokens.push(link_flags_type);
-      },
-      _ => {
+                tokens.push(link_flags_type);
+            }
+            _ => {}
+        }
 
-      }
-
-    }
-
-    tokens.push(String::from(
-      "SOURCE = src
+        tokens.push(String::from(
+            "SOURCE = src
 TARGET = target
 SOURCE_TARGET = $(TARGET)
 SOURCE_FILES = $(SOURCE)/*.cpp
@@ -102,10 +99,10 @@ TEST_OBJ_FILES = $(TEST_TARGET)/*.o
 include @(TUP_PLATFORM).tup",
         ));
 
-    match *project_kind {
-      ProjectKind::Static | ProjectKind::Shared => {
-        tokens.push(String::from(
-          "ifeq ($(LIB_TYPE),static)
+        match *project_kind {
+            ProjectKind::Static | ProjectKind::Shared => {
+                tokens.push(String::from(
+                    "ifeq ($(LIB_TYPE),static)
   EXTENSION = $(STATIC)
 else
   ifeq ($(LIB_TYPE),shared)

--- a/hatch/src/bin/hatch.rs
+++ b/hatch/src/bin/hatch.rs
@@ -1,66 +1,65 @@
-extern crate hatch;
 extern crate clap;
+extern crate hatch;
 extern crate yaml_rust;
 
 use std::collections::HashMap;
 
-use hatch::cli::commands::Command;
-use hatch::cli::commands::run::Run;
 use clap::App;
-use yaml_rust::YamlLoader;
-use hatch::hatch_error::{ HatchResult, MissingParameterError };
-use hatch::cli::commands::new::New;
-use hatch::cli::commands::update::Update;
 use hatch::cli::commands::build::Build;
+use hatch::cli::commands::new::New;
+use hatch::cli::commands::run::Run;
 use hatch::cli::commands::test::Test;
+use hatch::cli::commands::update::Update;
+use hatch::cli::commands::Command;
 use hatch::constants;
 use hatch::generators::tup::Tup;
+use hatch::hatch_error::{HatchResult, MissingParameterError};
+use yaml_rust::YamlLoader;
 
 fn do_me_a_hatch() -> HatchResult<()> {
-  let cli = include_str!("cli.yml");
-  let docs = YamlLoader::load_from_str(cli)?;
-  let doc = &docs[0];
-  let matches = App::from_yaml(doc).get_matches();
-  let (name, args) = matches.subcommand();
+    let cli = include_str!("cli.yml");
+    let docs = YamlLoader::load_from_str(cli)?;
+    let doc = &docs[0];
+    let matches = App::from_yaml(doc).get_matches();
+    let (name, args) = matches.subcommand();
 
-  // TODO: get the generator from the CLI and inject into commands
-  let generator = Box::new(Tup{});
+    // TODO: get the generator from the CLI and inject into commands
+    let generator = Box::new(Tup {});
 
-  let mut subcommands: HashMap<&'static str, Box<Command>> = HashMap::new();
-  let run_command = Box::new(Run::new());
-  subcommands.insert(constants::RUN_NAME, run_command);
+    let mut subcommands: HashMap<&'static str, Box<Command>> = HashMap::new();
+    let run_command = Box::new(Run::new());
+    subcommands.insert(constants::RUN_NAME, run_command);
 
-  let new_command = Box::new(New::new());
-  subcommands.insert(constants::NEW_NAME, new_command);
+    let new_command = Box::new(New::new());
+    subcommands.insert(constants::NEW_NAME, new_command);
 
-  let update_command = Box::new(Update::new());
-  subcommands.insert(constants::UPDATE_NAME, update_command);
+    let update_command = Box::new(Update::new());
+    subcommands.insert(constants::UPDATE_NAME, update_command);
 
-  let build_command = Box::new(Build::new());
-  subcommands.insert(constants::BUILD_NAME, build_command);
+    let build_command = Box::new(Build::new());
+    subcommands.insert(constants::BUILD_NAME, build_command);
 
-  let test_command = Box::new(Test::new());
-  subcommands.insert(constants::TEST_NAME, test_command);
+    let test_command = Box::new(Test::new());
+    subcommands.insert(constants::TEST_NAME, test_command);
 
-  let subcommand = subcommands.get(name).ok_or_else(|| MissingParameterError)?;
+    let subcommand = subcommands.get(name).ok_or_else(|| MissingParameterError)?;
 
-  // TODO: args.unwrap is bad, don't do this, it should be resultified
-  subcommand.execute(generator, args.unwrap())?;
-  Ok(())
+    // TODO: args.unwrap is bad, don't do this, it should be resultified
+    subcommand.execute(generator, args.unwrap())?;
+    Ok(())
 }
 
 fn main() {
+    println!("running hatch...");
 
-  println!("running hatch...");
-
-  match do_me_a_hatch() {
-    Ok(()) => {
-      println!("done");
-      ()
-    },
-    Err(e) => {
-      println!("error: {:?}", e);
-      ()
+    match do_me_a_hatch() {
+        Ok(()) => {
+            println!("done");
+            ()
+        }
+        Err(e) => {
+            println!("error: {:?}", e);
+            ()
+        }
     }
-  }
 }

--- a/hatch/src/bin/hatch.rs
+++ b/hatch/src/bin/hatch.rs
@@ -14,6 +14,7 @@ use hatch::cli::commands::update::Update;
 use hatch::cli::commands::build::Build;
 use hatch::cli::commands::test::Test;
 use hatch::constants;
+use hatch::generators::tup::Tup;
 
 fn do_me_a_hatch() -> HatchResult<()> {
   let cli = include_str!("cli.yml");
@@ -23,7 +24,7 @@ fn do_me_a_hatch() -> HatchResult<()> {
   let (name, args) = matches.subcommand();
 
   // TODO: get the generator from the CLI and inject into commands
-  // let generator;
+  let generator = Box::new(Tup{});
 
   let mut subcommands: HashMap<&'static str, Box<Command>> = HashMap::new();
   let run_command = Box::new(Run::new());
@@ -44,7 +45,7 @@ fn do_me_a_hatch() -> HatchResult<()> {
   let subcommand = subcommands.get(name).ok_or_else(|| MissingParameterError)?;
 
   // TODO: args.unwrap is bad, don't do this, it should be resultified
-  subcommand.execute(args.unwrap())?;
+  subcommand.execute(generator, args.unwrap())?;
   Ok(())
 }
 

--- a/hatch/src/cli/commands/build.rs
+++ b/hatch/src/cli/commands/build.rs
@@ -13,7 +13,7 @@ impl<'build> Build {
 }
 
 impl<'command> Command<'command> for Build {
-  fn execute(&self, args: &ArgMatches<'command>) -> HatchResult<()> {
+  fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()> {
     let (project_path, project) = self.read_project_context(args)?;
     println!("Building project...\n");
     self.build(&project_path)?;

--- a/hatch/src/cli/commands/build.rs
+++ b/hatch/src/cli/commands/build.rs
@@ -1,26 +1,26 @@
-use hatch_error::{ HatchResult };
-use clap::{ ArgMatches };
+use clap::ArgMatches;
 use cli::commands::Command;
-use generators::Generator;
 use generators::tup::Tup;
+use generators::Generator;
+use hatch_error::HatchResult;
 
 pub struct Build;
 
 impl<'build> Build {
-  pub fn new() -> Build {
-    Build
-  }
+    pub fn new() -> Build {
+        Build
+    }
 }
 
 impl<'command> Command<'command> for Build {
-  fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()> {
-    let (project_path, project) = self.read_project_context(args)?;
-    println!("Building project...\n");
-    self.build(&project_path)?;
-    println!("Generating assets...\n");
-    // TODO: make a trait object so we can dynamic dispatch on a command line arg for generator
-    let generator: Box<Generator> = Box::new(Tup{});
-    self.generate_assets(generator, project_path, &project)?;
-    Ok(())
-  }
+    fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()> {
+        let (project_path, project) = self.read_project_context(args)?;
+        println!("Building project...\n");
+        self.build(&project_path)?;
+        println!("Generating assets...\n");
+        // TODO: make a trait object so we can dynamic dispatch on a command line arg for generator
+        let generator: Box<Generator> = Box::new(Tup {});
+        self.generate_assets(generator, project_path, &project)?;
+        Ok(())
+    }
 }

--- a/hatch/src/cli/commands/mod.rs
+++ b/hatch/src/cli/commands/mod.rs
@@ -1,128 +1,136 @@
-pub mod new;
-pub mod update;
 pub mod build;
-pub mod test;
+pub mod new;
 pub mod run;
+pub mod test;
+pub mod update;
 
-use hatch_error::HatchResult;
-use clap::{ ArgMatches };
-use std::path::PathBuf;
-use deps::dependency::Dependency;
-use project::ProjectKind;
-use constants::{ ARGS, PROJECT_NAME, PROJECT_PATH, VERSION, TYPE, INCLUDE, GENERATOR };
-use std::path::Path;
-use platform::os;
 use assets::PlatformKind;
-use std::process;
-use hatch_error::InvalidPathError;
-use generators::Generator;
-use project::Project;
-use std::fs::File;
-use serde_yaml;
-use std::io::Read;
+use clap::ArgMatches;
+use constants::{ARGS, GENERATOR, INCLUDE, PROJECT_NAME, PROJECT_PATH, TYPE, VERSION};
+use deps::dependency::Dependency;
 use failure::ResultExt;
 use generators::get_generator;
+use generators::Generator;
+use hatch_error::HatchResult;
+use hatch_error::InvalidPathError;
+use platform::os;
+use project::Project;
+use project::ProjectKind;
+use serde_yaml;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process;
 
 pub trait Command<'command> {
-  fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()>;
+    fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()>;
 
-  fn read_project_context(&self, args: &ArgMatches<'command>) -> HatchResult<(PathBuf, Project)> {
-    let project_path = if args.is_present(PROJECT_PATH) {
-      PathBuf::from(value_t!(args, PROJECT_PATH, String).unwrap().as_str())
-    } else {
-      PathBuf::from("./")
-    };
+    fn read_project_context(&self, args: &ArgMatches<'command>) -> HatchResult<(PathBuf, Project)> {
+        let project_path = if args.is_present(PROJECT_PATH) {
+            PathBuf::from(value_t!(args, PROJECT_PATH, String).unwrap().as_str())
+        } else {
+            PathBuf::from("./")
+        };
 
-    let project = {
-      let project_path_ref = project_path.as_path();
-      let mut data = String::new();
-      File::open(&project_path_ref)?.read_to_string(&mut data)?;
-      serde_yaml::from_str::<Project>(&data)?
-    };
+        let project = {
+            let project_path_ref = project_path.as_path();
+            let mut data = String::new();
+            File::open(&project_path_ref)?.read_to_string(&mut data)?;
+            serde_yaml::from_str::<Project>(&data)?
+        };
 
-    Ok((project_path, project))
-  }
-
-  fn generator(&self, args: &ArgMatches<'command>) -> Option<Box<Generator>> {
-    let generator = value_t!(args, GENERATOR, String).ok();
-    get_generator(&generator);
-    None
-  }
-
-  fn project_name(&self, args: &ArgMatches<'command>) -> Option<String> {
-    value_t!(args, PROJECT_NAME, String).ok()
-  }
-
-  fn project_path(&self, args: &ArgMatches<'command>) -> PathBuf {
-    if args.is_present(PROJECT_PATH) {
-      PathBuf::from(value_t!(args, PROJECT_PATH, String).unwrap().as_str())
-    } else {
-      PathBuf::from("./")
+        Ok((project_path, project))
     }
-  }
 
-  fn project_version(&self, args: &ArgMatches<'command>) -> String {
-    if args.is_present(VERSION) {
-      value_t!(args, VERSION, String).unwrap()
-    } else {
-      "0.0.1".to_owned()
+    fn generator(&self, args: &ArgMatches<'command>) -> Option<Box<Generator>> {
+        let generator = value_t!(args, GENERATOR, String).ok();
+        get_generator(&generator);
+        None
     }
-  }
 
-  fn project_kind(&self, args: &ArgMatches<'command>) -> ProjectKind {
-    if args.is_present(TYPE) {
-      let type_arg: String = value_t!(args, TYPE, String).unwrap();
-      ProjectKind::from_str(type_arg.as_str())
-    } else {
-      ProjectKind::default()
+    fn project_name(&self, args: &ArgMatches<'command>) -> Option<String> {
+        value_t!(args, PROJECT_NAME, String).ok()
     }
-  }
 
-  fn parse_arguments_from_cli(&self, cli_args: &ArgMatches<'command>) -> Vec<String> {
-    if let Some(arguments) = cli_args.values_of(ARGS) {
-      arguments.map(String::from).collect()
-    } else {
-      Vec::new()
-    }
-  }
-
-  fn parse_dependencies<'func>(&self, args: &ArgMatches<'func>) -> Vec<Dependency> {
-    if let Some(values) = args.values_of(INCLUDE) {
-      values.map(String::from).map(Dependency::new).collect::<Vec<Dependency>>()
-    } else {
-      Vec::new()
-    }
-  }
-
-  fn build(&self, project_path: &Path) -> HatchResult<()> {
-    if let Some(path) = project_path.to_str() {
-      let command = format!("cd {} && tup", path);
-      let mut shell: String;
-      let mut args: Vec<String>;
-      match os::platform_type() {
-        PlatformKind::Windows => {
-          shell = String::from("cmd");
-          args = vec![String::from("/C"), command];
-        },
-        _ => {
-          shell = String::from("sh");
-          args = vec![String::from("-c"), command];
+    fn project_path(&self, args: &ArgMatches<'command>) -> PathBuf {
+        if args.is_present(PROJECT_PATH) {
+            PathBuf::from(value_t!(args, PROJECT_PATH, String).unwrap().as_str())
+        } else {
+            PathBuf::from("./")
         }
-      }
-
-      let mut child = process::Command::new(shell).args(args).spawn()?;
-      child.wait()?;
-
-      Ok(())
-    } else {
-      Err(InvalidPathError)?
     }
-  }
 
-  fn generate_assets(&self, generator: Box<Generator>, project_path: PathBuf, project: &Project) -> HatchResult<()> {
-    generator.generate_assets(project_path, project).with_context(|e| {
-      format!("asset generation failed : `{}`", e)
-    })?;
-    Ok(())
-  }
+    fn project_version(&self, args: &ArgMatches<'command>) -> String {
+        if args.is_present(VERSION) {
+            value_t!(args, VERSION, String).unwrap()
+        } else {
+            "0.0.1".to_owned()
+        }
+    }
+
+    fn project_kind(&self, args: &ArgMatches<'command>) -> ProjectKind {
+        if args.is_present(TYPE) {
+            let type_arg: String = value_t!(args, TYPE, String).unwrap();
+            ProjectKind::from_str(type_arg.as_str())
+        } else {
+            ProjectKind::default()
+        }
+    }
+
+    fn parse_arguments_from_cli(&self, cli_args: &ArgMatches<'command>) -> Vec<String> {
+        if let Some(arguments) = cli_args.values_of(ARGS) {
+            arguments.map(String::from).collect()
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn parse_dependencies<'func>(&self, args: &ArgMatches<'func>) -> Vec<Dependency> {
+        if let Some(values) = args.values_of(INCLUDE) {
+            values
+                .map(String::from)
+                .map(Dependency::new)
+                .collect::<Vec<Dependency>>()
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn build(&self, project_path: &Path) -> HatchResult<()> {
+        if let Some(path) = project_path.to_str() {
+            let command = format!("cd {} && tup", path);
+            let mut shell: String;
+            let mut args: Vec<String>;
+            match os::platform_type() {
+                PlatformKind::Windows => {
+                    shell = String::from("cmd");
+                    args = vec![String::from("/C"), command];
+                }
+                _ => {
+                    shell = String::from("sh");
+                    args = vec![String::from("-c"), command];
+                }
+            }
+
+            let mut child = process::Command::new(shell).args(args).spawn()?;
+            child.wait()?;
+
+            Ok(())
+        } else {
+            Err(InvalidPathError)?
+        }
+    }
+
+    fn generate_assets(
+        &self,
+        generator: Box<Generator>,
+        project_path: PathBuf,
+        project: &Project,
+    ) -> HatchResult<()> {
+        generator
+            .generate_assets(project_path, project)
+            .with_context(|e| format!("asset generation failed : `{}`", e))?;
+        Ok(())
+    }
 }

--- a/hatch/src/cli/commands/mod.rs
+++ b/hatch/src/cli/commands/mod.rs
@@ -44,7 +44,9 @@ pub trait Command<'command> {
   }
 
   fn generator(&self, args: &ArgMatches<'command>) -> Option<Box<Generator>> {
-    get_generator(value_t!(args, GENERATOR, String).ok())
+    let generator = value_t!(args, GENERATOR, String).ok();
+    get_generator(&generator);
+    None
   }
 
   fn project_name(&self, args: &ArgMatches<'command>) -> Option<String> {

--- a/hatch/src/cli/commands/mod.rs
+++ b/hatch/src/cli/commands/mod.rs
@@ -23,7 +23,7 @@ use std::io::Read;
 use failure::ResultExt;
 
 pub trait Command<'command> {
-  fn execute(&self, args: &ArgMatches<'command>) -> HatchResult<()>;
+  fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()>;
 
   fn read_project_context(&self, args: &ArgMatches<'command>) -> HatchResult<(PathBuf, Project)> {
     let project_path = if args.is_present(PROJECT_PATH) {

--- a/hatch/src/cli/commands/mod.rs
+++ b/hatch/src/cli/commands/mod.rs
@@ -9,7 +9,7 @@ use clap::{ ArgMatches };
 use std::path::PathBuf;
 use deps::dependency::Dependency;
 use project::ProjectKind;
-use constants::{ ARGS, PROJECT_NAME, PROJECT_PATH, VERSION, TYPE, INCLUDE };
+use constants::{ ARGS, PROJECT_NAME, PROJECT_PATH, VERSION, TYPE, INCLUDE, GENERATOR };
 use std::path::Path;
 use platform::os;
 use assets::PlatformKind;
@@ -21,6 +21,7 @@ use std::fs::File;
 use serde_yaml;
 use std::io::Read;
 use failure::ResultExt;
+use generators::get_generator;
 
 pub trait Command<'command> {
   fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()>;
@@ -40,6 +41,10 @@ pub trait Command<'command> {
     };
 
     Ok((project_path, project))
+  }
+
+  fn generator(&self, args: &ArgMatches<'command>) -> Option<Box<Generator>> {
+    get_generator(value_t!(args, GENERATOR, String).ok())
   }
 
   fn project_name(&self, args: &ArgMatches<'command>) -> Option<String> {

--- a/hatch/src/cli/commands/new.rs
+++ b/hatch/src/cli/commands/new.rs
@@ -1,50 +1,50 @@
-use std::fs;
-use std::io::prelude::*;
-use clap::{ ArgMatches };
-use cli::commands::{ Command };
+use clap::ArgMatches;
+use cli::commands::Command;
 use deps::clone_project_deps;
-use locations::{ hatchfile_path, modules_path };
-use hatch_error::{ HatchResult };
-use project::{ CompilerOptions, Project };
-use serde_yaml;
 use generators::tup::Tup;
 use generators::Generator;
+use hatch_error::HatchResult;
+use locations::{hatchfile_path, modules_path};
+use project::{CompilerOptions, Project};
+use serde_yaml;
+use std::fs;
+use std::io::prelude::*;
 
 pub struct New;
 
 impl<'new> New {
-  pub fn new() -> New {
-    New
-  }
+    pub fn new() -> New {
+        New
+    }
 }
 
 impl<'command> Command<'command> for New {
-  fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()> {
-    let name = self.project_name(args).unwrap_or("".to_string());
-    let version = self.project_version(args);
-    let kind = self.project_kind(args);
-    let dir_path = self.project_path(args).join(&name);
-    let hatch_file = hatchfile_path(&dir_path);
-    let includes = self.parse_dependencies(args);
-    fs::create_dir(&dir_path)?;
-    fs::create_dir(modules_path(&dir_path))?;
-    fs::create_dir(dir_path.join("src"))?;
-    fs::create_dir(dir_path.join("target"))?;
-    fs::create_dir_all(dir_path.join("test").join("src"))?;
-    fs::create_dir(dir_path.join("test").join("target"))?;
-    if !includes.is_empty() {
-      println!("Installing project dependencies...");
-      clone_project_deps(modules_path(&dir_path).as_path(), &includes)?;
+    fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()> {
+        let name = self.project_name(args).unwrap_or("".to_string());
+        let version = self.project_version(args);
+        let kind = self.project_kind(args);
+        let dir_path = self.project_path(args).join(&name);
+        let hatch_file = hatchfile_path(&dir_path);
+        let includes = self.parse_dependencies(args);
+        fs::create_dir(&dir_path)?;
+        fs::create_dir(modules_path(&dir_path))?;
+        fs::create_dir(dir_path.join("src"))?;
+        fs::create_dir(dir_path.join("target"))?;
+        fs::create_dir_all(dir_path.join("test").join("src"))?;
+        fs::create_dir(dir_path.join("test").join("target"))?;
+        if !includes.is_empty() {
+            println!("Installing project dependencies...");
+            clone_project_deps(modules_path(&dir_path).as_path(), &includes)?;
+        }
+        println!("Creating Hatch.yml file...");
+        let compiler_options = CompilerOptions::default_from_kind(&kind);
+        let project = Project::new(name, version, kind, compiler_options, includes);
+        let yaml_output = serde_yaml::to_string(&project)?;
+        let mut file = fs::File::create(hatch_file)?;
+        file.write_all(yaml_output.as_bytes())?;
+        println!("Generating assets...");
+        self.generate_assets(generator, dir_path, &project)?;
+        println!("Finished");
+        Ok(())
     }
-    println!("Creating Hatch.yml file...");
-    let compiler_options = CompilerOptions::default_from_kind(&kind);
-    let project = Project::new(name, version, kind, compiler_options, includes);
-    let yaml_output = serde_yaml::to_string(&project)?;
-    let mut file = fs::File::create(hatch_file)?;
-    file.write_all(yaml_output.as_bytes())?;
-    println!("Generating assets...");
-    self.generate_assets(generator, dir_path, &project)?;
-    println!("Finished");
-    Ok(())
-  }
 }

--- a/hatch/src/cli/commands/new.rs
+++ b/hatch/src/cli/commands/new.rs
@@ -8,6 +8,7 @@ use hatch_error::{ HatchResult };
 use project::{ CompilerOptions, Project };
 use serde_yaml;
 use generators::tup::Tup;
+use generators::Generator;
 
 pub struct New;
 
@@ -18,7 +19,7 @@ impl<'new> New {
 }
 
 impl<'command> Command<'command> for New {
-  fn execute(&self, args: &ArgMatches<'command>) -> HatchResult<()> {
+  fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()> {
     let name = self.project_name(args).unwrap_or("".to_string());
     let version = self.project_version(args);
     let kind = self.project_kind(args);
@@ -42,7 +43,6 @@ impl<'command> Command<'command> for New {
     let mut file = fs::File::create(hatch_file)?;
     file.write_all(yaml_output.as_bytes())?;
     println!("Generating assets...");
-    let generator = Box::new(Tup{});
     self.generate_assets(generator, dir_path, &project)?;
     println!("Finished");
     Ok(())

--- a/hatch/src/cli/commands/run.rs
+++ b/hatch/src/cli/commands/run.rs
@@ -16,10 +16,9 @@ impl<'run> Run {
 }
 
 impl<'command> Command<'command> for Run {
-  fn execute(&self, args: &ArgMatches<'command>) -> Action {
+  fn execute(&self , generator: Box<Generator>, args: &ArgMatches<'command>) -> Action {
     let (project_path, project) = self.read_project_context(args)?;
-    let generator = Tup{};
-    Generator::generate_assets(&generator, project_path.clone(), &project).with_context(|e| {
+    self.generate_assets(generator, project_path.clone(), &project).with_context(|e| {
       format!("asset generation failed : `{}`", e)
     })?;
 

--- a/hatch/src/cli/commands/run.rs
+++ b/hatch/src/cli/commands/run.rs
@@ -1,42 +1,44 @@
-use std::process::Command as ProcessCommand;
+use clap::ArgMatches;
 use cli::commands::Command;
-use clap::{ ArgMatches };
-use project::ProjectKind;
-use hatch_error::Action;
+use failure::ResultExt;
 use generators::tup::Tup;
 use generators::Generator;
-use failure::ResultExt;
+use hatch_error::Action;
+use project::ProjectKind;
+use std::process::Command as ProcessCommand;
 
 pub struct Run;
 
 impl<'run> Run {
-  pub fn new() -> Run {
-    Run
-  }
+    pub fn new() -> Run {
+        Run
+    }
 }
 
 impl<'command> Command<'command> for Run {
-  fn execute(&self , generator: Box<Generator>, args: &ArgMatches<'command>) -> Action {
-    let (project_path, project) = self.read_project_context(args)?;
-    self.generate_assets(generator, project_path.clone(), &project).with_context(|e| {
-      format!("asset generation failed : `{}`", e)
-    })?;
+    fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> Action {
+        let (project_path, project) = self.read_project_context(args)?;
+        self.generate_assets(generator, project_path.clone(), &project)
+            .with_context(|e| format!("asset generation failed : `{}`", e))?;
 
-    match *project.kind() {
-      ProjectKind::Binary => {
-        println!("Generating assets...\n");
-        let generator = Box::new(Tup{});
-        self.generate_assets(generator, project_path.clone(), &project)?;
-        println!("Building project...\n");
-        self.build(&project_path)?;
-        println!("Executing...\n");
-        let executable_path = format!("{}target/{}", project_path.display(), project.name());
-        let run_arguments =  self.parse_arguments_from_cli(args);
-        let mut child = ProcessCommand::new(&executable_path).args(run_arguments).spawn()?;
-        child.wait()?;
-        Ok(())
-      }
-      _ => Ok(())
+        match *project.kind() {
+            ProjectKind::Binary => {
+                println!("Generating assets...\n");
+                let generator = Box::new(Tup {});
+                self.generate_assets(generator, project_path.clone(), &project)?;
+                println!("Building project...\n");
+                self.build(&project_path)?;
+                println!("Executing...\n");
+                let executable_path =
+                    format!("{}target/{}", project_path.display(), project.name());
+                let run_arguments = self.parse_arguments_from_cli(args);
+                let mut child = ProcessCommand::new(&executable_path)
+                    .args(run_arguments)
+                    .spawn()?;
+                child.wait()?;
+                Ok(())
+            }
+            _ => Ok(()),
+        }
     }
-  }
 }

--- a/hatch/src/cli/commands/test.rs
+++ b/hatch/src/cli/commands/test.rs
@@ -14,10 +14,9 @@ impl<'test> Test {
 }
 
 impl<'command> Command<'command> for Test {
-  fn execute(&self, args: &ArgMatches<'command>) -> HatchResult<()> {
+  fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()> {
     let (project_path, project) = self.read_project_context(args)?;
     println!("Generating assets...\n");
-    let generator: Box<Generator> = Box::new(Tup::new());
     self.generate_assets(generator, project_path.clone(), &project)?;
     println!("Building project...\n");
     self.build(&project_path).with_context(|e| {

--- a/hatch/src/cli/commands/test.rs
+++ b/hatch/src/cli/commands/test.rs
@@ -1,32 +1,37 @@
-use std::process::Command as ProcessCommand;
+use clap::ArgMatches;
 use cli::commands::Command;
-use hatch_error::{ HatchResult, ResultExt };
-use clap::{ ArgMatches };
 use generators::tup::Tup;
 use generators::Generator;
+use hatch_error::{HatchResult, ResultExt};
+use std::process::Command as ProcessCommand;
 
 pub struct Test;
 
 impl<'test> Test {
-  pub fn new() -> Test {
-    Test
-  }
+    pub fn new() -> Test {
+        Test
+    }
 }
 
 impl<'command> Command<'command> for Test {
-  fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()> {
-    let (project_path, project) = self.read_project_context(args)?;
-    println!("Generating assets...\n");
-    self.generate_assets(generator, project_path.clone(), &project)?;
-    println!("Building project...\n");
-    self.build(&project_path).with_context(|e| {
-      format!("Failed to build project : {}", e)
-    })?;
-    println!("Executing tests...\n");
-    let test_executable_path = format!("{}test/target/{}.test", project_path.display(), project.name());
-    let test_arguments = Command::parse_arguments_from_cli(self, args);
-    let mut child = ProcessCommand::new(&test_executable_path).args(test_arguments).spawn()?;
-    child.wait()?;
-    Ok(())
-  }
+    fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()> {
+        let (project_path, project) = self.read_project_context(args)?;
+        println!("Generating assets...\n");
+        self.generate_assets(generator, project_path.clone(), &project)?;
+        println!("Building project...\n");
+        self.build(&project_path)
+            .with_context(|e| format!("Failed to build project : {}", e))?;
+        println!("Executing tests...\n");
+        let test_executable_path = format!(
+            "{}test/target/{}.test",
+            project_path.display(),
+            project.name()
+        );
+        let test_arguments = Command::parse_arguments_from_cli(self, args);
+        let mut child = ProcessCommand::new(&test_executable_path)
+            .args(test_arguments)
+            .spawn()?;
+        child.wait()?;
+        Ok(())
+    }
 }

--- a/hatch/src/cli/commands/update.rs
+++ b/hatch/src/cli/commands/update.rs
@@ -2,6 +2,7 @@ use hatch_error::HatchResult;
 use clap::{ ArgMatches };
 use cli::commands::Command;
 use generators::tup::Tup;
+use generators::Generator;
 
 pub struct Update;
 
@@ -12,9 +13,8 @@ impl<'update> Update {
 }
 
 impl<'command> Command<'command> for Update {
-  fn execute(&self, args: &ArgMatches<'command>) -> HatchResult<()> {
+  fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()> {
     let (path, project) = self.read_project_context(args)?;
-    let generator = Box::new(Tup{});
     self.generate_assets(generator, path.clone(), &project)?;
     Ok(())
   }

--- a/hatch/src/cli/commands/update.rs
+++ b/hatch/src/cli/commands/update.rs
@@ -1,21 +1,21 @@
-use hatch_error::HatchResult;
-use clap::{ ArgMatches };
+use clap::ArgMatches;
 use cli::commands::Command;
 use generators::tup::Tup;
 use generators::Generator;
+use hatch_error::HatchResult;
 
 pub struct Update;
 
 impl<'update> Update {
-  pub fn new() -> Update {
-    Update
-  }
+    pub fn new() -> Update {
+        Update
+    }
 }
 
 impl<'command> Command<'command> for Update {
-  fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()> {
-    let (path, project) = self.read_project_context(args)?;
-    self.generate_assets(generator, path.clone(), &project)?;
-    Ok(())
-  }
+    fn execute(&self, generator: Box<Generator>, args: &ArgMatches<'command>) -> HatchResult<()> {
+        let (path, project) = self.read_project_context(args)?;
+        self.generate_assets(generator, path.clone(), &project)?;
+        Ok(())
+    }
 }

--- a/hatch/src/constants.rs
+++ b/hatch/src/constants.rs
@@ -19,7 +19,8 @@ pub static UPDATE_NAME: &str = "update";
 pub static RUN_NAME: &str = "run";
 pub static TEST_NAME: &str = "test";
 
-pub static CATCH_HEADER_URL: &str = "https://github.com/catchorg/Catch2/releases/download/v2.1.1/catch.hpp";
+pub static CATCH_HEADER_URL: &str =
+    "https://github.com/catchorg/Catch2/releases/download/v2.1.1/catch.hpp";
 
 pub static GENERATOR: &str = "generator";
 

--- a/hatch/src/constants.rs
+++ b/hatch/src/constants.rs
@@ -22,3 +22,5 @@ pub static TEST_NAME: &str = "test";
 pub static CATCH_HEADER_URL: &str = "https://github.com/catchorg/Catch2/releases/download/v2.1.1/catch.hpp";
 
 pub static GENERATOR: &str = "generator";
+
+pub static TUP: &str = "tup";

--- a/hatch/src/constants.rs
+++ b/hatch/src/constants.rs
@@ -20,3 +20,5 @@ pub static RUN_NAME: &str = "run";
 pub static TEST_NAME: &str = "test";
 
 pub static CATCH_HEADER_URL: &str = "https://github.com/catchorg/Catch2/releases/download/v2.1.1/catch.hpp";
+
+pub static GENERATOR: &str = "generator";

--- a/hatch/src/deps/dependency.rs
+++ b/hatch/src/deps/dependency.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use std::fmt;
+use std::path::PathBuf;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Dependency {

--- a/hatch/src/deps/mod.rs
+++ b/hatch/src/deps/mod.rs
@@ -3,21 +3,21 @@ mod tests;
 
 pub mod dependency;
 
-use hatch_error::{HatchError, HatchResult};
-use git2::Repository;
-use std::collections::HashSet;
-use std::fs;
-use std::path::Path;
 use self::dependency::Dependency;
+use git2::Repository;
+use hatch_error::SerdeYamlError;
+use hatch_error::{HatchError, HatchResult};
 use locations::hatchfile_path;
-use std::fs::File;
-use std::io::Read;
 use project::Project;
 use serde_yaml;
-use hatch_error::SerdeYamlError;
+use std::collections::HashSet;
+use std::fs;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
 
 pub fn clone_dep(url: &str, path: &Path) {
-  let _ = Repository::clone(url, path);
+    let _ = Repository::clone(url, path);
 }
 
 fn walk(path: &Path, callback: &mut FnMut(&Path) -> HatchResult<bool>) -> HatchResult<()> {
@@ -36,19 +36,17 @@ fn walk(path: &Path, callback: &mut FnMut(&Path) -> HatchResult<bool>) -> HatchR
     Ok(())
 }
 
-pub fn clone_project_deps(path: &Path,
-                          dependencies: &Vec<Dependency>) -> HatchResult<()>
-{
-  let mut visited: HashSet<String> = HashSet::new();
-  let mut errored: Vec<HatchError> = Vec::new();
+pub fn clone_project_deps(path: &Path, dependencies: &Vec<Dependency>) -> HatchResult<()> {
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut errored: Vec<HatchError> = Vec::new();
 
     // All dependencies are cloned into here
     let registry = &path;
 
-  // Clone the dependencies specified on the command line
-  dependencies.iter().for_each(|dep| {
-    clone_dep(&dep.url(), &path.join(&dep.name()));
-  });
+    // Clone the dependencies specified on the command line
+    dependencies.iter().for_each(|dep| {
+        clone_dep(&dep.url(), &path.join(&dep.name()));
+    });
 
     // Clone the dependencies dependencies
     walk(path, &mut |dir| {
@@ -74,44 +72,44 @@ pub fn clone_project_deps(path: &Path,
     Ok(())
 }
 
-fn clone_nested_project_deps(registry: &Path,
-                             path: &Path,
-                             errored: &mut Vec<HatchError>,
-                             visited: &mut HashSet<String>)
-{
-
-  // TODO: Do one of these:
-  // 1. Put this back in task::read_project
-  // 2. Make a constructor for Project that takes a &Path
-  let mut data = String::new();
-  let file = File::open(&path);
-  let _ = file.unwrap().read_to_string(&mut data);
-  match serde_yaml::from_str::<Project>(&data) {
-    Err(e) => {
-      // TODO: For some reason, I can't push this error
-      // errored.push(SerdeYamlError{});
-    },
-    Ok(current_project) => {
-      if !visited.contains( &current_project.name().to_owned()) {
-        current_project.dependencies().iter().for_each(|dep| {
-          clone_dep(&dep.url(), &registry.join(dep.name()).as_path());
-        });
-        let _ = visited.insert(current_project.name().to_owned());
-      }
+fn clone_nested_project_deps(
+    registry: &Path,
+    path: &Path,
+    errored: &mut Vec<HatchError>,
+    visited: &mut HashSet<String>,
+) {
+    // TODO: Do one of these:
+    // 1. Put this back in task::read_project
+    // 2. Make a constructor for Project that takes a &Path
+    let mut data = String::new();
+    let file = File::open(&path);
+    let _ = file.unwrap().read_to_string(&mut data);
+    match serde_yaml::from_str::<Project>(&data) {
+        Err(e) => {
+            // TODO: For some reason, I can't push this error
+            // errored.push(SerdeYamlError{});
+        }
+        Ok(current_project) => {
+            if !visited.contains(&current_project.name().to_owned()) {
+                current_project.dependencies().iter().for_each(|dep| {
+                    clone_dep(&dep.url(), &registry.join(dep.name()).as_path());
+                });
+                let _ = visited.insert(current_project.name().to_owned());
+            }
+        }
     }
-  }
 
-//  match task::read_project(path) {
-//    Err(e) => {
-//      errored.push(e);
-//    },
-//    Ok(current_project) => {
-//      if !visited.contains(&current_project.name().to_owned()) {
-//        current_project.dependencies().iter().for_each(|dep| {
-//          clone_dep(&dep.url(), &registry.join(dep.name()).as_path());
-//        });
-//        let _ = visited.insert(current_project.name().to_owned());
-//      }
-//    }
-//  }
+    //  match task::read_project(path) {
+    //    Err(e) => {
+    //      errored.push(e);
+    //    },
+    //    Ok(current_project) => {
+    //      if !visited.contains(&current_project.name().to_owned()) {
+    //        current_project.dependencies().iter().for_each(|dep| {
+    //          clone_dep(&dep.url(), &registry.join(dep.name()).as_path());
+    //        });
+    //        let _ = visited.insert(current_project.name().to_owned());
+    //      }
+    //    }
+    //  }
 }

--- a/hatch/src/generators/mod.rs
+++ b/hatch/src/generators/mod.rs
@@ -1,19 +1,19 @@
-use project::Project;
-use hatch_error::HatchResult;
-use std::path::PathBuf;
-use generators::tup::Tup;
 use constants::TUP;
+use generators::tup::Tup;
+use hatch_error::HatchResult;
+use project::Project;
+use std::path::PathBuf;
 
 pub mod tup;
 
 pub trait Generator {
-  // TODO: this interface should take references
-  fn generate_assets(&self, project_path: PathBuf, project: &Project) -> HatchResult<()>;
+    // TODO: this interface should take references
+    fn generate_assets(&self, project_path: PathBuf, project: &Project) -> HatchResult<()>;
 }
 
 pub fn get_generator(generator: &Option<String>) -> Option<Box<Generator>> {
-  match generator.as_ref().map(|s| &s[..]) {
-    Some(s) if s == TUP => Some(Box::new(Tup{}) as Box<Generator>),
-    _ => Some(Box::new(Tup{}) as Box<Generator>),
-  }
+    match generator.as_ref().map(|s| &s[..]) {
+        Some(s) if s == TUP => Some(Box::new(Tup {}) as Box<Generator>),
+        _ => Some(Box::new(Tup {}) as Box<Generator>),
+    }
 }

--- a/hatch/src/generators/mod.rs
+++ b/hatch/src/generators/mod.rs
@@ -2,6 +2,7 @@ use project::Project;
 use hatch_error::HatchResult;
 use std::path::PathBuf;
 use generators::tup::Tup;
+use constants::TUP;
 
 pub mod tup;
 
@@ -10,8 +11,9 @@ pub trait Generator {
   fn generate_assets(&self, project_path: PathBuf, project: &Project) -> HatchResult<()>;
 }
 
-pub fn get_generator(generator: Option<String>) -> Option<Box<Generator>> {
-  match generator {
+pub fn get_generator(generator: &Option<String>) -> Option<Box<Generator>> {
+  match generator.as_ref().map(|s| &s[..]) {
+    Some(s) if s == TUP => Some(Box::new(Tup{}) as Box<Generator>),
     _ => Some(Box::new(Tup{}) as Box<Generator>),
   }
 }

--- a/hatch/src/generators/mod.rs
+++ b/hatch/src/generators/mod.rs
@@ -1,10 +1,17 @@
 use project::Project;
 use hatch_error::HatchResult;
 use std::path::PathBuf;
+use generators::tup::Tup;
 
 pub mod tup;
 
 pub trait Generator {
   // TODO: this interface should take references
   fn generate_assets(&self, project_path: PathBuf, project: &Project) -> HatchResult<()>;
+}
+
+pub fn get_generator(generator: Option<String>) -> Option<Box<Generator>> {
+  match generator {
+    _ => Some(Box::new(Tup{}) as Box<Generator>),
+  }
 }

--- a/hatch/src/generators/tup.rs
+++ b/hatch/src/generators/tup.rs
@@ -1,44 +1,48 @@
-use generators::Generator;
-use project::Project;
 use assets::builder::Builder;
-use platform::os;
-use hatch_error::HatchError;
 use failure::ResultExt;
+use generators::Generator;
+use hatch_error::HatchError;
+use platform::os;
+use project::Project;
 use std::path::PathBuf;
 
 pub struct Tup;
 
 impl Tup {
-  pub fn new() -> Tup {
-    Tup{}
-  }
+    pub fn new() -> Tup {
+        Tup {}
+    }
 }
 
 impl Generator for Tup {
-  fn generate_assets(&self, project_path: PathBuf, project: &Project) -> Result<(), HatchError> {
-    let mut builder = Builder::new(project_path, project);
-    builder.config();
-    builder.test_tupfile();
-    builder.tuprules();
-    builder.tupfile();
-    builder.tupfile_ini();
+    fn generate_assets(&self, project_path: PathBuf, project: &Project) -> Result<(), HatchError> {
+        let mut builder = Builder::new(project_path, project);
+        builder.config();
+        builder.test_tupfile();
+        builder.tuprules();
+        builder.tupfile();
+        builder.tupfile_ini();
 
-    let platform_type = os::platform_type();
-    builder.platform(&platform_type);
+        let platform_type = os::platform_type();
+        builder.platform(&platform_type);
 
-    if let Ok(catch_header) = builder.catch_header() {
-      builder.add_asset(catch_header);
+        if let Ok(catch_header) = builder.catch_header() {
+            builder.add_asset(catch_header);
+        }
+
+        let catch_definition = builder.catch_definition();
+        builder.add_asset(catch_definition);
+        let assets = Builder::collect_assets(builder);
+
+        for asset in assets {
+            asset.write().with_context(|e| {
+                format!(
+                    "Failed to generate asset: `{}` : {}",
+                    asset.path().display(),
+                    e
+                )
+            })?;
+        }
+        Ok(())
     }
-
-    let catch_definition = builder.catch_definition();
-    builder.add_asset(catch_definition);
-    let assets = Builder::collect_assets(builder);
-
-    for asset in assets {
-      asset.write().with_context(|e| {
-        format!("Failed to generate asset: `{}` : {}", asset.path().display(), e)
-      })?;
-    }
-    Ok(())
-  }
 }

--- a/hatch/src/hatch_error/mod.rs
+++ b/hatch/src/hatch_error/mod.rs
@@ -1,5 +1,5 @@
-pub use failure::ResultExt;
 pub use failure::Error as HatchError;
+pub use failure::ResultExt;
 
 pub type HatchResult<T> = Result<T, HatchError>;
 
@@ -32,7 +32,6 @@ pub struct NullError;
 #[derive(Fail, Debug)]
 #[fail(display = "")]
 pub struct MissingParameterError;
-
 
 #[derive(Fail, Debug)]
 #[fail(display = "Failed to do Serde Yaml stuff")]

--- a/hatch/src/lib.rs
+++ b/hatch/src/lib.rs
@@ -1,66 +1,67 @@
 #![forbid(unsafe_code)]
 extern crate serde;
-#[macro_use] extern crate serde_derive;
+#[macro_use]
+extern crate serde_derive;
 extern crate serde_yaml;
 
 #[macro_use]
 pub extern crate clap;
 #[macro_use]
 pub extern crate failure;
+extern crate core;
 pub extern crate git2;
 pub extern crate os_info;
 pub extern crate reqwest;
 pub extern crate yaml_rust;
-extern crate core;
 
-pub mod project;
-pub mod cli;
-pub mod hatch_error;
-pub mod yaml;
 pub mod assets;
-pub mod task;
-pub mod deps;
-pub mod platform;
-pub mod locations;
+pub mod cli;
 pub mod constants;
+pub mod deps;
 pub mod generators;
+pub mod hatch_error;
+pub mod locations;
+pub mod platform;
+pub mod project;
+pub mod task;
+pub mod yaml;
 
 #[cfg(test)]
 mod tests {
-  #[test]
-  fn it_works() {
-//    use serde_yaml;
-//
-//    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-//    struct Length { a: f64 }
-//    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-//    struct Point { x: f64, y: Length }
-//
-//    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-//    struct Cfg {
-//      compiler: String,
-//    }
-//
-//    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-//    struct CompiledProj {
-//      name: String,
-//      version: String,
-//      cfg: Cfg,
-//    }
-//
-//    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-//    struct HeaderOnlyProj {
-//      name: String,
-//      version: String,
-//      cfg: Cfg,
-//    }
-//    // let proj = Proj { name: "foo".to_string(), version: "0.1.0".to_string(), cfg: Some(Cfg { compiler: "g++".to_string() }) };
-//    let proj = Proj { name: "foo".to_string(), version: "0.1.0".to_string(), cfg: None };
-//    let s = serde_yaml::to_string(&proj).unwrap();
-//    println!("{}", s);
-//    assert_eq!(s, "---\nx: 1\n\"y\": 2");
-//
-//    let deserialized_point: Point = serde_yaml::from_str(&s).unwrap();
-//    assert_eq!(point, deserialized_point);
-  }
+    #[test]
+    fn it_works() {
+        //    use serde_yaml;
+        //
+        //    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        //    struct Length { a: f64 }
+        //    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        //    struct Point { x: f64, y: Length }
+        //
+        //    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        //    struct Cfg {
+        //      compiler: String,
+        //    }
+        //
+        //    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        //    struct CompiledProj {
+        //      name: String,
+        //      version: String,
+        //      cfg: Cfg,
+        //    }
+        //
+        //    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        //    struct HeaderOnlyProj {
+        //      name: String,
+        //      version: String,
+        //      cfg: Cfg,
+        //    }
+        //    // let proj = Proj { name: "foo".to_string(), version: "0.1.0".to_string(), cfg: Some(Cfg { compiler: "g++".to_string() }) };
+        //    let proj = Proj { name: "foo".to_string(), version: "0.1.0".to_string(), cfg: None };
+        //    let s = serde_yaml::to_string(&proj).unwrap();
+        //    println!("{}", s);
+        //    assert_eq!(s, "---\nx: 1\n\"y\": 2");
+        //
+        //    let deserialized_point: Point = serde_yaml::from_str(&s).unwrap();
+        //    assert_eq!(point, deserialized_point);
+    }
 }

--- a/hatch/src/platform/arch.rs
+++ b/hatch/src/platform/arch.rs
@@ -1,8 +1,11 @@
-use std::mem::size_of;
 use std::fmt;
+use std::mem::size_of;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub enum Arch { X64, X86 }
+pub enum Arch {
+    X64,
+    X86,
+}
 
 impl AsRef<Arch> for Arch {
     fn as_ref(&self) -> &Arch {

--- a/hatch/src/project/compiler_options.rs
+++ b/hatch/src/project/compiler_options.rs
@@ -1,67 +1,72 @@
 use platform::arch::Arch;
-use project::Target;
 use project::ProjectKind;
+use project::Target;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct CompilerOptions {
-  compiler: String,
-  compiler_flags: String,
-  linker_flags: String,
-  arch: Arch,
-  target: Target,
+    compiler: String,
+    compiler_flags: String,
+    linker_flags: String,
+    arch: Arch,
+    target: Target,
 }
 
 impl CompilerOptions {
-  pub fn new(compiler: String, compiler_flags: String, linker_flags: String,
-             arch: Arch, target: Target) -> CompilerOptions {
-    CompilerOptions {
-      compiler,
-      compiler_flags,
-      linker_flags,
-      arch,
-      target
+    pub fn new(
+        compiler: String,
+        compiler_flags: String,
+        linker_flags: String,
+        arch: Arch,
+        target: Target,
+    ) -> CompilerOptions {
+        CompilerOptions {
+            compiler,
+            compiler_flags,
+            linker_flags,
+            arch,
+            target,
+        }
     }
-  }
 
-  pub fn default() -> CompilerOptions {
-    let compiler: String = String::from("g++");
-    let compiler_flags = String::from("-c");
-    let linker_flags = String::from("-v");
-    let mut arch: Arch = Arch::X64;
-    if let Some(architecture) = Arch::architecture() {
-      arch = architecture;
+    pub fn default() -> CompilerOptions {
+        let compiler: String = String::from("g++");
+        let compiler_flags = String::from("-c");
+        let linker_flags = String::from("-v");
+        let mut arch: Arch = Arch::X64;
+        if let Some(architecture) = Arch::architecture() {
+            arch = architecture;
+        }
+        let target: Target = Target::Debug;
+
+        CompilerOptions {
+            compiler,
+            compiler_flags,
+            linker_flags,
+            arch,
+            target,
+        }
     }
-    let target: Target = Target::Debug;
 
-    CompilerOptions {
-      compiler,
-      compiler_flags,
-      linker_flags,
-      arch,
-      target
+    pub fn default_from_kind(kind: &ProjectKind) -> Option<CompilerOptions> {
+        match *kind {
+            ProjectKind::HeaderOnly => None,
+            _ => Some(CompilerOptions::default()),
+        }
     }
-  }
 
-  pub fn default_from_kind(kind: &ProjectKind) -> Option<CompilerOptions> {
-    match *kind {
-      ProjectKind::HeaderOnly => None,
-      _ => Some(CompilerOptions::default())
+    pub fn compiler(&self) -> &str {
+        &self.compiler
     }
-  }
-
-  pub fn compiler(&self) -> &str {
-    &self.compiler
-  }
-  pub fn compiler_flags(&self) -> &str {
-    &self.compiler_flags
-  }
-  pub fn linker_flags(&self) -> &str {
-    &self.linker_flags
-  }
-  pub fn arch(&self) -> &Arch {
-    &self.arch
-  }
-  pub fn target(&self) -> &Target {
-    &self.target
-  }
+    pub fn compiler_flags(&self) -> &str {
+        &self.compiler_flags
+    }
+    pub fn linker_flags(&self) -> &str {
+        &self.linker_flags
+    }
+    pub fn arch(&self) -> &Arch {
+        &self.arch
+    }
+    pub fn target(&self) -> &Target {
+        &self.target
+    }
 }

--- a/hatch/src/project/mod.rs
+++ b/hatch/src/project/mod.rs
@@ -10,24 +10,45 @@ use deps::dependency::Dependency;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Project {
-  name : String,
-  version: String,
-  kind: ProjectKind,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  compiler_options: Option<CompilerOptions>,
-  #[serde(skip_serializing_if = "Vec::is_empty")]
-  dependencies: Vec<Dependency>,
+    name: String,
+    version: String,
+    kind: ProjectKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    compiler_options: Option<CompilerOptions>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    dependencies: Vec<Dependency>,
 }
 
 impl Project {
-  pub fn new(name: String, version: String, kind: ProjectKind,
-             compiler_options: Option<CompilerOptions>, includes: Vec<Dependency>) -> Project {
-    Project { name, version, kind, compiler_options, dependencies: includes }
-  }
+    pub fn new(
+        name: String,
+        version: String,
+        kind: ProjectKind,
+        compiler_options: Option<CompilerOptions>,
+        includes: Vec<Dependency>,
+    ) -> Project {
+        Project {
+            name,
+            version,
+            kind,
+            compiler_options,
+            dependencies: includes,
+        }
+    }
 
-  pub fn name(&self) -> &str { self.name.as_str() }
-  pub fn version(&self) -> &str { self.version.as_str() }
-  pub fn kind(&self) -> &ProjectKind { &self.kind }
-  pub fn compiler_options(&self) -> &Option<CompilerOptions> { &self.compiler_options }
-  pub fn dependencies(&self) -> &Vec<Dependency> { &self.dependencies }
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+    pub fn version(&self) -> &str {
+        self.version.as_str()
+    }
+    pub fn kind(&self) -> &ProjectKind {
+        &self.kind
+    }
+    pub fn compiler_options(&self) -> &Option<CompilerOptions> {
+        &self.compiler_options
+    }
+    pub fn dependencies(&self) -> &Vec<Dependency> {
+        &self.dependencies
+    }
 }

--- a/hatch/src/project/project_kind.rs
+++ b/hatch/src/project/project_kind.rs
@@ -1,19 +1,24 @@
-use constants::{ BIN, STATIC, SHARED, HEADER };
+use constants::{BIN, HEADER, SHARED, STATIC};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub enum ProjectKind { Binary, Static, Shared, HeaderOnly }
+pub enum ProjectKind {
+    Binary,
+    Static,
+    Shared,
+    HeaderOnly,
+}
 
-impl  ProjectKind {
-  pub fn from_str(project_kind_str :&str) -> ProjectKind {
-    match project_kind_str {
-      arg if arg == BIN => ProjectKind::Binary,
-      arg if arg == STATIC => ProjectKind::Static,
-      arg if arg == SHARED => ProjectKind::Shared,
-      arg if arg == HEADER => ProjectKind::HeaderOnly,
-      _ => ProjectKind::Static
+impl ProjectKind {
+    pub fn from_str(project_kind_str: &str) -> ProjectKind {
+        match project_kind_str {
+            arg if arg == BIN => ProjectKind::Binary,
+            arg if arg == STATIC => ProjectKind::Static,
+            arg if arg == SHARED => ProjectKind::Shared,
+            arg if arg == HEADER => ProjectKind::HeaderOnly,
+            _ => ProjectKind::Static,
+        }
     }
-  }
-  pub fn default() -> ProjectKind {
-    ProjectKind::Static
-  }
+    pub fn default() -> ProjectKind {
+        ProjectKind::Static
+    }
 }

--- a/hatch/src/project/target.rs
+++ b/hatch/src/project/target.rs
@@ -1,2 +1,5 @@
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub enum Target { Debug, Release }
+pub enum Target {
+    Debug,
+    Release,
+}


### PR DESCRIPTION
This PR allows the generator to be generic so that it can be passed to the commands directly. It is the beginning of decoupling Hatch from the tup generator. 