### PR TITLE
issue112 - Use self paramter in collect_assets method

### DIFF
--- a/hatch/src/generators/tup/builder.rs
+++ b/hatch/src/generators/tup/builder.rs
@@ -30,7 +30,7 @@ impl<'builder> Builder<'builder> {
         }
     }
 
-    pub fn collect_assets(self) -> Vec<ProjectAsset> { self.assets }
+    pub fn assets(self) -> Vec<ProjectAsset> { self.assets }
 
     pub fn add_asset(&mut self, asset: ProjectAsset) {
         self.assets.push(asset);

--- a/hatch/src/generators/tup/builder.rs
+++ b/hatch/src/generators/tup/builder.rs
@@ -30,9 +30,7 @@ impl<'builder> Builder<'builder> {
         }
     }
 
-    pub fn collect_assets(builder: Builder) -> Vec<ProjectAsset> {
-        builder.assets
-    }
+    pub fn collect_assets(self) -> Vec<ProjectAsset> { self.assets }
 
     pub fn add_asset(&mut self, asset: ProjectAsset) {
         self.assets.push(asset);

--- a/hatch/src/generators/tup/tests/builder.rs
+++ b/hatch/src/generators/tup/tests/builder.rs
@@ -18,7 +18,7 @@ fn add_asset() {
 
     // My reason for adopting this static method, is so I clarify to reader that we are eating the
     // Builder. It is gone. Not ever coming back.
-    let assets = AssetBuilder::collect_assets(asset_builder);
+    let assets = AssetBuilder::assets(asset_builder);
 
     assert_eq!(assets.len(), 1);
 

--- a/hatch/src/generators/tup/tup.rs
+++ b/hatch/src/generators/tup/tup.rs
@@ -32,7 +32,7 @@ impl Generator for Tup {
 
         let catch_definition = builder.add_catch_definition();
         builder.add_asset(catch_definition);
-        let assets = builder.collect_assets();
+        let assets = builder.assets();
 
         for asset in assets {
             asset.write().with_context(|e| {

--- a/hatch/src/generators/tup/tup.rs
+++ b/hatch/src/generators/tup/tup.rs
@@ -32,7 +32,7 @@ impl Generator for Tup {
 
         let catch_definition = builder.add_catch_definition();
         builder.add_asset(catch_definition);
-        let assets = Builder::collect_assets(builder);
+        let assets = builder.collect_assets();
 
         for asset in assets {
             asset.write().with_context(|e| {


### PR DESCRIPTION
I realized that one can pass `self` without a `&` in a trait method. This means we can keep a builder-like interface and still eat the builder.

I converted the trait method `collect_assets` to take advantage of this feature.